### PR TITLE
Fix stress block length

### DIFF
--- a/src/data/preguntas.ts
+++ b/src/data/preguntas.ts
@@ -225,7 +225,7 @@ export const bloqueExtralaboral = [
 ];
 
 export const bloqueEstres = [
-  { bloque: 1, preguntas: [0, 29], enunciado: "A continuación encontrará una serie de síntomas y situaciones, marque con qué frecuencia las ha experimentado en los últimos meses.", condicional: null, obligatorio: true }
+  { bloque: 1, preguntas: [0, 30], enunciado: "A continuación encontrará una serie de síntomas y situaciones, marque con qué frecuencia las ha experimentado en los últimos meses.", condicional: null, obligatorio: true }
 ];
 
 export const preguntasA = [


### PR DESCRIPTION
## Summary
- include the last question in `bloqueEstres`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6850cc901be48331aa446ae5702a1b78