### PR TITLE
Fix numbering

### DIFF
--- a/src/components/BloquesDePreguntas.tsx
+++ b/src/components/BloquesDePreguntas.tsx
@@ -117,7 +117,7 @@ export default function BloquesDePreguntas({ bloques, preguntas, onFinish }: Pro
   return (
     <div key={idx} className="mb-4">
       <label className="font-semibold block mb-1">
-        {preg.texto.replace(/^\d+\./, "")}
+        {`${idx + 1}. ${preg.texto.replace(/^\d+\.?\s*/, "")}`}
       </label>
       {preg.tipo === "likert" && (
         <select


### PR DESCRIPTION
## Summary
- show question numbers when rendering each question

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6850d3947b1c8331b9cf0a753ccb3bb7