### PR TITLE
Fix ordering of Form B conditional blocks

### DIFF
--- a/src/data/preguntas.ts
+++ b/src/data/preguntas.ts
@@ -199,17 +199,17 @@ export const bloquesFormaB = [
   },
   {
     bloque: 12,
-    preguntas: [78, 87], // 80-88 (primera parte del bloque condicional, si la F3 es afirmativa)
-    enunciado: "Las siguientes preguntas están relacionadas con la satisfacción, reconocimiento y la seguridad que le ofrece su trabajo.",
-    condicional: "F3",
-    obligatorio: false
-  },
-  {
-    bloque: 13,
     preguntas: [88, 88], // índice de la pregunta filtro F3
     enunciado: "¿En mi trabajo debo brindar servicio a clientes o usuarios?",
     condicional: null,
     obligatorio: true
+  },
+  {
+    bloque: 13,
+    preguntas: [78, 87], // 80-88 (primera parte del bloque condicional, si la F3 es afirmativa)
+    enunciado: "Las siguientes preguntas están relacionadas con la satisfacción, reconocimiento y la seguridad que le ofrece su trabajo.",
+    condicional: "F3",
+    obligatorio: false
   },
   {
     bloque: 14,


### PR DESCRIPTION
## Summary
- adjust Form B blocks so the filter question appears before conditional sections

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_6850d740be608331bdc1d8e791d31691