### PR TITLE
Refactor Forma B result output

### DIFF
--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -153,8 +153,8 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro }: Pr
         "Nivel Forma A": d.resultadoFormaA?.total?.nivel ?? "",
       }),
       ...(tab === "formaB" && {
-        "Puntaje Forma B": d.resultadoFormaB?.puntajeTotal ?? "",
-        "Nivel Forma B": d.resultadoFormaB?.nivelTotal ?? "",
+        "Puntaje Forma B": d.resultadoFormaB?.total?.transformado ?? "",
+        "Nivel Forma B": d.resultadoFormaB?.total?.nivel ?? "",
       }),
       ...(tab === "extralaboral" && {
         "Puntaje Extralaboral": d.resultadoExtralaboral?.puntajeTransformadoTotal ?? "",
@@ -209,8 +209,8 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro }: Pr
                 )}
                 {tipo === "formaB" && (
                   <>
-                    <td>{d.resultadoFormaB?.puntajeTotal ?? ""}</td>
-                    <td>{d.resultadoFormaB?.nivelTotal ?? ""}</td>
+                    <td>{d.resultadoFormaB?.total?.transformado ?? ""}</td>
+                    <td>{d.resultadoFormaB?.total?.nivel ?? ""}</td>
                   </>
                 )}
                 {tipo === "extralaboral" && (


### PR DESCRIPTION
## Summary
- restructure `calcularFormaB` to output per-dimension and per-domain objects with `suma`, `transformado` and `nivel`
- update dashboard to read new `resultadoFormaB` shape

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run build` *(fails: many missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6850e57f2b808331887be8aaf4f3d8aa