### PR TITLE
Fix Forma B result fallback

### DIFF
--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -171,8 +171,14 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro }: Pr
         "Nivel Forma A": d.resultadoFormaA?.total?.nivel ?? "",
       }),
       ...(tab === "formaB" && {
-        "Puntaje Forma B": d.resultadoFormaB?.total?.transformado ?? "",
-        "Nivel Forma B": d.resultadoFormaB?.total?.nivel ?? "",
+        "Puntaje Forma B":
+          d.resultadoFormaB?.total?.transformado ??
+          d.resultadoFormaB?.puntajeTransformadoTotal ??
+          "",
+        "Nivel Forma B":
+          d.resultadoFormaB?.total?.nivel ??
+          d.resultadoFormaB?.nivelTotal ??
+          "",
       }),
       ...(tab === "extralaboral" && {
         "Puntaje Extralaboral": d.resultadoExtralaboral?.puntajeTransformadoTotal ?? "",
@@ -227,8 +233,16 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro }: Pr
                 )}
                 {tipo === "formaB" && (
                   <>
-                    <td>{d.resultadoFormaB?.total?.transformado ?? ""}</td>
-                    <td>{d.resultadoFormaB?.total?.nivel ?? ""}</td>
+                    <td>
+                      {d.resultadoFormaB?.total?.transformado ??
+                        d.resultadoFormaB?.puntajeTransformadoTotal ??
+                        ""}
+                    </td>
+                    <td>
+                      {d.resultadoFormaB?.total?.nivel ??
+                        d.resultadoFormaB?.nivelTotal ??
+                        ""}
+                    </td>
                   </>
                 )}
                 {tipo === "extralaboral" && (


### PR DESCRIPTION
## Summary
- support older Forma B result structure when exporting to Excel
- show Forma B results with old or new keys in the table

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6850f14d60f88331a1b872d78b56c059