### PR TITLE
Extend question type to support stress option

### DIFF
--- a/src/components/BloquesDePreguntas.tsx
+++ b/src/components/BloquesDePreguntas.tsx
@@ -10,7 +10,7 @@ type Bloque = {
 
 type Pregunta = {
   texto: string;
-  tipo: "likert" | "yesno";
+  tipo: "likert" | "yesno" | "estres";
   filtro?: boolean; // true si es pregunta filtro (sí/no)
 };
 


### PR DESCRIPTION
## Summary
- allow `Pregunta` to accept `"estres"` as a valid `tipo`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6851ab9d3bc48331a13af957f9a58ca4