### PR TITLE
Load credentials from JSON config

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,11 @@ npm run lint
 - `public/` - Static assets served directly
 - `index.html` - Entry point for the application
 
+## Sample credentials
+
+Default demo accounts are defined in `src/config/credentials.json`:
+
+- **Psicóloga**: `psicologa` / `cogent2024`
+- **Sonria**: `sonria` / `sonria123`
+- **Aeropuerto**: `aeropuerto` / `eldorado123`
+

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -1,12 +1,5 @@
 import React, { useState } from "react";
-
-// Puedes agregar aquí las claves/empresas permitidas
-const usuarios = [
-  { usuario: "psicologa", password: "cogent2024", rol: "psicologa" },
-  { usuario: "sonria", password: "sonria123", rol: "dueno", empresa: "Sonria" },
-  { usuario: "aeropuerto", password: "eldorado123", rol: "dueno", empresa: "Aeropuerto El Dorado" },
-  // Agrega aquí más empresas si quieres
-];
+import usuarios from "../config/credentials.json";
 
 type Props = {
   onLogin: (rol: "psicologa" | "dueno", empresa?: string) => void;
@@ -61,9 +54,13 @@ export default function Login({ onLogin, onCancel }: Props) {
           </button>
         )}
         <div className="text-xs mt-2 text-gray-400">
-          <b>Psicóloga</b>: psicologa / cogent2024<br />
-          <b>Sonria</b>: sonria / sonria123<br />
-          <b>Aeropuerto</b>: aeropuerto / eldorado123
+          {usuarios.map((u) => (
+            <div key={u.usuario}>
+              <b>{u.rol === "psicologa" ? "Psicóloga" : u.empresa}</b>: {u.usuario}
+              {" / "}
+              {u.password}
+            </div>
+          ))}
         </div>
       </form>
     </div>

--- a/src/config/credentials.json
+++ b/src/config/credentials.json
@@ -1,0 +1,5 @@
+[
+  { "usuario": "psicologa", "password": "cogent2024", "rol": "psicologa" },
+  { "usuario": "sonria", "password": "sonria123", "rol": "dueno", "empresa": "Sonria" },
+  { "usuario": "aeropuerto", "password": "eldorado123", "rol": "dueno", "empresa": "Aeropuerto El Dorado" }
+]

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -10,6 +10,7 @@
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",
     "noEmit": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"]
-    }
+    },
+    "resolveJsonModule": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- fetch login credentials from external `credentials.json`
- allow JSON imports by updating TS configs
- document demo credentials in the README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6851aba674c883318db92246cc23b7bb