### PR TITLE
Add global A+Extralaboral score

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import { calcularEstres } from "./utils/calcularEstres";
 import { calcularExtralaboral } from "./utils/calcularExtralaboral";
 import { calcularFormaA } from "./utils/calcularFormaA";
 import { calcularFormaB } from "./utils/calcularFormaB";
+import { calcularGlobalAExtrala } from "./utils/calcularGlobalA";
 
 type RolUsuario = "ninguno" | "psicologa" | "dueno";
 
@@ -48,6 +49,7 @@ export default function App() {
   const [resultadoExtralaboral, setResultadoExtralaboral] = useState<any>(null);
   const [resultadoFormaA, setResultadoFormaA] = useState<any>(null);
   const [resultadoFormaB, setResultadoFormaB] = useState<any>(null);
+  const [resultadoGlobalAExtra, setResultadoGlobalAExtra] = useState<any>(null);
 
   // Manejo de login (muy básico)
   const [rol, setRol] = useState<RolUsuario>("ninguno");
@@ -57,12 +59,20 @@ export default function App() {
     if (step === "final") {
       // Calcula resultados por formulario
       let resultadoForma = null;
+      let resultadoGlobal = null;
       if (formType === "A" && respuestas.bloques) {
         const arr = Array.from({ length: preguntasA.length }, (_, i) =>
           respuestas.bloques[i] ?? ""
         );
         resultadoForma = calcularFormaA(arr);
         setResultadoFormaA(resultadoForma);
+        if (resultadoExtralaboral) {
+          resultadoGlobal = calcularGlobalAExtrala(
+            resultadoForma.total.suma,
+            resultadoExtralaboral.puntajeBrutoTotal
+          );
+          setResultadoGlobalAExtra(resultadoGlobal);
+        }
       } else if (formType === "B" && respuestas.bloques) {
         const arr = Array.from({ length: preguntasB.length }, (_, i) =>
           respuestas.bloques[i] ?? ""
@@ -77,6 +87,7 @@ export default function App() {
         respuestas,
         resultadoFormaA: formType === "A" ? resultadoForma : undefined,
         resultadoFormaB: formType === "B" ? resultadoForma : undefined,
+        resultadoGlobalAExtralaboral: formType === "A" ? resultadoGlobal : undefined,
         resultadoEstres,
         resultadoExtralaboral,
         tipo: formType,

--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -95,6 +95,7 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro }: Pr
   const datosB = datosMostrados.filter((d) => d.tipo === "B" && d.resultadoFormaB);
   const datosExtra = datosMostrados.filter((d) => d.resultadoExtralaboral);
   const datosEstres = datosMostrados.filter((d) => d.resultadoEstres);
+  const datosGlobalAE = datosMostrados.filter((d) => d.resultadoGlobalAExtralaboral);
 
   // ---- Resúmenes para gráficos ----
   const resumenNivel = (datos: any[], key: string, niveles: string[]) =>
@@ -112,6 +113,7 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro }: Pr
   const resumenB = resumenNivel(datosB, "resultadoFormaB", nivelesForma);
   const resumenExtra = resumenNivel(datosExtra, "resultadoExtralaboral", nivelesExtra);
   const resumenEstres = resumenNivel(datosEstres, "resultadoEstres", nivelesEstres);
+  const resumenGlobalAE = resumenNivel(datosGlobalAE, "resultadoGlobalAExtralaboral", nivelesForma);
 
   // ---- Promedios por dominio/dimensión ----
   function calcularPromedios(
@@ -158,6 +160,7 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro }: Pr
     if (tab === "formaA") datosExportar = datosA;
     else if (tab === "formaB") datosExportar = datosB;
     else if (tab === "extralaboral") datosExportar = datosExtra;
+    else if (tab === "globalAE") datosExportar = datosGlobalAE;
     else if (tab === "estres") datosExportar = datosEstres;
 
     const filas = datosExportar.map((d, i) => ({
@@ -183,6 +186,10 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro }: Pr
       ...(tab === "extralaboral" && {
         "Puntaje Extralaboral": d.resultadoExtralaboral?.puntajeTransformadoTotal ?? "",
         "Nivel Extralaboral": d.resultadoExtralaboral?.nivelGlobal ?? "",
+      }),
+      ...(tab === "globalAE" && {
+        "Puntaje Global A+Extra": d.resultadoGlobalAExtralaboral?.puntajeGlobal ?? "",
+        "Nivel Global": d.resultadoGlobalAExtralaboral?.nivelGlobal ?? "",
       }),
       ...(tab === "estres" && {
         "Puntaje Estrés": d.resultadoEstres?.puntajeTransformado ?? "",
@@ -213,6 +220,7 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro }: Pr
               {tipo === "formaA" && (<><th>Puntaje Forma A</th><th>Nivel Forma A</th></>)}
               {tipo === "formaB" && (<><th>Puntaje Forma B</th><th>Nivel Forma B</th></>)}
               {tipo === "extralaboral" && (<><th>Puntaje Extralaboral</th><th>Nivel Extra</th></>)}
+              {tipo === "globalAE" && (<><th>Puntaje Global A+Extra</th><th>Nivel Global</th></>)}
               {tipo === "estres" && (<><th>Puntaje Estrés</th><th>Nivel Estrés</th></>)}
               <th>Fecha</th>
             </tr>
@@ -249,6 +257,12 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro }: Pr
                   <>
                     <td>{d.resultadoExtralaboral?.puntajeTransformadoTotal ?? ""}</td>
                     <td>{d.resultadoExtralaboral?.nivelGlobal ?? ""}</td>
+                  </>
+                )}
+                {tipo === "globalAE" && (
+                  <>
+                    <td>{d.resultadoGlobalAExtralaboral?.puntajeGlobal ?? ""}</td>
+                    <td>{d.resultadoGlobalAExtralaboral?.nivelGlobal ?? ""}</td>
                   </>
                 )}
                 {tipo === "estres" && (
@@ -345,6 +359,7 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro }: Pr
           <TabsTrigger value="formaA">Forma A (Intralaboral)</TabsTrigger>
           <TabsTrigger value="formaB">Forma B (Intralaboral)</TabsTrigger>
           <TabsTrigger value="extralaboral">Extralaboral</TabsTrigger>
+          <TabsTrigger value="globalAE">Global A + Extra</TabsTrigger>
           <TabsTrigger value="estres">Estrés</TabsTrigger>
         </TabsList>
 
@@ -424,6 +439,19 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro }: Pr
               <>
                 <GraficaBarraSimple resumen={resumenExtra} titulo="Niveles Extralaborales" />
                 {!soloGenerales && <TablaIndividual datos={datosExtra} tipo="extralaboral" />}
+              </>
+            )
+          }
+        </TabsContent>
+
+        {/* ---- GLOBAL A + EXTRA ---- */}
+        <TabsContent value="globalAE">
+          {datosGlobalAE.length === 0
+            ? <div className="text-gray-500 py-4">No hay resultados Globales.</div>
+            : (
+              <>
+                <GraficaBarraSimple resumen={resumenGlobalAE} titulo="Niveles Global A + Extra" />
+                {!soloGenerales && <TablaIndividual datos={datosGlobalAE} tipo="globalAE" />}
               </>
             )
           }


### PR DESCRIPTION
## Summary
- use `calcularGlobalAExtrala` when finishing the survey
- store combined score with other results
- show the new metric in DashboardResultados with charts, table and export option

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' because network access is disabled)*

------
https://chatgpt.com/codex/tasks/task_e_6851abb493348331aa76152fc0dd5b23