### PR TITLE
Add chart type selector

### DIFF
--- a/src/utils/calcularFormaA.ts
+++ b/src/utils/calcularFormaA.ts
@@ -59,11 +59,17 @@ export function calcularFormaA(respuestas: Respuestas) {
       (acc, num) => acc + respuestaAPuntaje(num, mapRespuestas[num] || ""),
       0
     );
-    const factor = factoresFormaA.dimensiones[dimension] ?? preguntas.length;
+    const factor =
+      factoresFormaA.dimensiones[
+        dimension as keyof typeof factoresFormaA.dimensiones
+      ] ?? preguntas.length;
     const transformado = Math.round(((suma * 100) / factor) * 10) / 10;
-    const baremo = baremosFormaA.dimensiones[dimension] || [];
+    const baremo =
+      baremosFormaA.dimensiones[
+        dimension as keyof typeof baremosFormaA.dimensiones
+      ] || [];
     const nivel =
-      baremo.find(b => transformado >= b.min && transformado <= b.max)?.nivel ||
+      baremo.find((b: any) => transformado >= b.min && transformado <= b.max)?.nivel ||
       "No clasificado";
     resultadoDimensiones[dimension] = { suma, transformado, nivel };
   });
@@ -74,11 +80,17 @@ export function calcularFormaA(respuestas: Respuestas) {
       (acc, num) => acc + respuestaAPuntaje(num, mapRespuestas[num] || ""),
       0
     );
-    const factor = factoresFormaA.dominios[dominio] ?? preguntas.length;
+    const factor =
+      factoresFormaA.dominios[
+        dominio as keyof typeof factoresFormaA.dominios
+      ] ?? preguntas.length;
     const transformado = Math.round(((suma * 100) / factor) * 10) / 10;
-    const baremo = baremosFormaA.dominios[dominio] || [];
+    const baremo =
+      baremosFormaA.dominios[
+        dominio as keyof typeof baremosFormaA.dominios
+      ] || [];
     const nivel =
-      baremo.find(b => transformado >= b.min && transformado <= b.max)?.nivel ||
+      baremo.find((b: any) => transformado >= b.min && transformado <= b.max)?.nivel ||
       "No clasificado";
     resultadoDominios[dominio] = { suma, transformado, nivel };
   });

--- a/src/utils/calcularFormaB.ts
+++ b/src/utils/calcularFormaB.ts
@@ -60,10 +60,18 @@ export function calcularFormaB(respuestas: string[]) {
       (acc, num) => acc + respuestaAPuntaje(num, mapRespuestas[num] || ""),
       0
     );
-    const factor = factoresFormaB.dimension[dimension] ?? preguntas.length;
+    const factor =
+      factoresFormaB.dimension[
+        dimension as keyof typeof factoresFormaB.dimension
+      ] ?? preguntas.length;
     const transformado = Math.round(((suma * 100) / factor) * 10) / 10;
-    const baremo = baremosFormaB.dimension[dimension] || [];
-    const nivel = baremo.find(b => transformado >= b.min && transformado <= b.max)?.nivel || "No clasificado";
+    const baremo =
+      baremosFormaB.dimension[
+        dimension as keyof typeof baremosFormaB.dimension
+      ] || [];
+    const nivel =
+      baremo.find((b: any) => transformado >= b.min && transformado <= b.max)?.nivel ||
+      "No clasificado";
     resultadosDimension[dimension] = { suma, transformado, nivel };
   });
 
@@ -74,10 +82,18 @@ export function calcularFormaB(respuestas: string[]) {
       (acc, num) => acc + respuestaAPuntaje(num, mapRespuestas[num] || ""),
       0
     );
-    const factor = factoresFormaB.dominio[dominio] ?? preguntas.length;
+    const factor =
+      factoresFormaB.dominio[
+        dominio as keyof typeof factoresFormaB.dominio
+      ] ?? preguntas.length;
     const transformado = Math.round(((suma * 100) / factor) * 10) / 10;
-    const baremo = baremosFormaB.dominio[dominio] || [];
-    const nivel = baremo.find(b => transformado >= b.min && transformado <= b.max)?.nivel || "No clasificado";
+    const baremo =
+      baremosFormaB.dominio[
+        dominio as keyof typeof baremosFormaB.dominio
+      ] || [];
+    const nivel =
+      baremo.find((b: any) => transformado >= b.min && transformado <= b.max)?.nivel ||
+      "No clasificado";
     resultadosDominio[dominio] = { suma, transformado, nivel };
   });
 


### PR DESCRIPTION
## Summary
- support changing chart type between bar, histogram and pie
- expose chart type selector in dashboard
- adjust calculations to satisfy TS compiler

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6851ad6d355c8331b18bacc1627e4547