### PR TITLE
Fix JSX closing tags in DashboardResults

### DIFF
--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -558,6 +558,7 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro, onBa
           Descargar PDF
         </button>
       </div>
-    </div>
-  );
-}
+      </div>
+      </div>
+    );
+  }


### PR DESCRIPTION
## Summary
- close missing div tags in `DashboardResultados.tsx`

## Testing
- `npm run build` *(fails: Cannot find module 'react')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6851f0e4d3e483318a5250c14259446a