### PR TITLE
Increase dashboard chart height

### DIFF
--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -305,9 +305,9 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro, onBa
     chartType: "bar" | "histogram" | "pie";
   }) {
     return (
-      <div className="flex-1">
+      <div className="flex-1 min-h-[350px]">
         <h4 className="font-bold mb-2 text-cogent-blue">{titulo}</h4>
-        <ResponsiveContainer width="100%" height={220}>
+        <ResponsiveContainer width="100%" height={350}>
           {chartType === "pie" ? (
             <PieChart>
               <Pie data={resumen} dataKey={keyData} nameKey="nombre" label>
@@ -346,9 +346,9 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro, onBa
     chartType: "bar" | "histogram" | "pie";
   }) {
     return (
-      <div className="flex-1">
+      <div className="flex-1 min-h-[350px]">
         <h4 className="font-bold mb-2 text-cogent-blue">{titulo}</h4>
-        <ResponsiveContainer width="100%" height={220}>
+        <ResponsiveContainer width="100%" height={350}>
           {chartType === "pie" ? (
             <PieChart>
               <Pie data={resumen} dataKey="cantidad" nameKey="nivel" label>


### PR DESCRIPTION
## Summary
- bump graph height to 350px and reserve space before rendering

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6851f3ddc2588331ad1c97020022d0e0