### PR TITLE
Fix Forma B result display

### DIFF
--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -182,10 +182,13 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro, onBa
         "Puntaje Forma B":
           d.resultadoFormaB?.total?.transformado ??
           d.resultadoFormaB?.puntajeTransformadoTotal ??
+          d.resultadoFormaB?.puntajeTransformado ??
+          d.resultadoFormaB?.puntajeTotalTransformado ??
           "",
         "Nivel Forma B":
           d.resultadoFormaB?.total?.nivel ??
           d.resultadoFormaB?.nivelTotal ??
+          d.resultadoFormaB?.nivel ??
           "",
       }),
       ...(tab === "extralaboral" && {
@@ -256,11 +259,14 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro, onBa
                     <td>
                       {d.resultadoFormaB?.total?.transformado ??
                         d.resultadoFormaB?.puntajeTransformadoTotal ??
+                        d.resultadoFormaB?.puntajeTransformado ??
+                        d.resultadoFormaB?.puntajeTotalTransformado ??
                         ""}
                     </td>
                     <td>
                       {d.resultadoFormaB?.total?.nivel ??
                         d.resultadoFormaB?.nivelTotal ??
+                        d.resultadoFormaB?.nivel ??
                         ""}
                     </td>
                   </>


### PR DESCRIPTION
## Summary
- show Forma B scores in dashboard tables

## Testing
- `npm run lint` *(fails: Cannot find package '/workspace/cogent_frontend/node_modules/@eslint/js/index.js')*

------
https://chatgpt.com/codex/tasks/task_e_6851f559ea9c8331b0bea2a0e493ddca