### PR TITLE
Add extra-laboral dimension view

### DIFF
--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -3,6 +3,7 @@ import { BarChart, Bar, PieChart, Pie, Cell, XAxis, YAxis, Tooltip, Legend, Resp
 import * as XLSX from "xlsx";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { exportElementToPDF } from "@/utils/pdfExport";
+import { dimensionesExtralaboral } from "@/data/esquemaExtralaboral";
 
 // Personaliza tus colores de barras
 const colores = ["#2a57d3", "#1db2f5", "#ffbc1c", "#f2600e", "#d7263d", "#9b59b6", "#45a049", "#0e668b", "#e67e22"];
@@ -71,12 +72,14 @@ const dimensionesB = [
 const nivelesEstres = ["Muy bajo", "Bajo", "Medio", "Alto", "Muy alto"];
 const nivelesExtra = ["Sin riesgo", "Riesgo bajo", "Riesgo medio", "Riesgo alto", "Riesgo muy alto"];
 const nivelesForma = ["Sin riesgo", "Riesgo bajo", "Riesgo medio", "Riesgo alto", "Riesgo muy alto"];
+const nombresExtra = dimensionesExtralaboral.map((d) => d.nombre);
 
 export default function DashboardResultados({ soloGenerales, empresaFiltro, onBack }: Props) {
   const [datos, setDatos] = useState<any[]>([]);
   const [empresaSeleccionada, setEmpresaSeleccionada] = useState(empresaFiltro || "todas");
   const [tab, setTab] = useState("formaA");
   const [tabIntra, setTabIntra] = useState("global"); // Para sub-tabs de formaA/B
+  const [tabExtra, setTabExtra] = useState("global");
 
   const [chartType, setChartType] = useState<"bar" | "histogram" | "pie">("bar");
   const pdfRef = useRef<HTMLDivElement>(null);
@@ -166,6 +169,7 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro, onBa
   const promediosDimensionesA = calcularPromedios(datosA, "resultadoFormaA", dimensionesA, "dimensiones");
   const promediosDominiosB = calcularPromedios(datosB, "resultadoFormaB", dominiosB, "dominios");
   const promediosDimensionesB = calcularPromedios(datosB, "resultadoFormaB", dimensionesB, "dimensiones");
+  const promediosDimensionesExtra = calcularPromedios(datosExtra, "resultadoExtralaboral", nombresExtra, "dimensiones");
 
   // ---- Exportar a Excel ----
   const handleExportar = () => {
@@ -298,6 +302,41 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro, onBa
                   </>
                 )}
                 <td>{d.fecha ? new Date(d.fecha).toLocaleString() : ""}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    );
+  }
+
+  function TablaDimensiones({ datos, nombres }: { datos: any[]; nombres: string[] }) {
+    if (datos.length === 0)
+      return <div className="py-6 text-gray-400">No hay resultados individuales para mostrar.</div>;
+    return (
+      <div className="overflow-x-auto">
+        <table className="w-full text-xs border mt-2">
+          <thead className="bg-cogent-blue text-white">
+            <tr>
+              <th>#</th>
+              <th>Empresa</th>
+              <th>Nombre</th>
+              {nombres.map((n, idx) => (
+                <th key={idx}>{n}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {datos.map((d, i) => (
+              <tr key={i} className="border-b">
+                <td>{i + 1}</td>
+                <td>{d.ficha?.empresa}</td>
+                <td>{d.ficha?.nombre}</td>
+                {nombres.map((nombre, j) => (
+                  <td key={j}>
+                    {d.resultadoExtralaboral?.dimensiones?.find((x: any) => x.nombre === nombre)?.puntajeTransformado ?? ""}
+                  </td>
+                ))}
               </tr>
             ))}
           </tbody>
@@ -508,15 +547,32 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro, onBa
 
         {/* ---- EXTRALABORAL ---- */}
         <TabsContent value="extralaboral">
-          {datosExtra.length === 0
-            ? <div className="text-gray-500 py-4">No hay resultados Extralaborales.</div>
-            : (
-              <>
-                <GraficaBarraSimple resumen={resumenExtra} titulo="Niveles Extralaborales" chartType={chartType} />
-                {!soloGenerales && <TablaIndividual datos={datosExtra} tipo="extralaboral" />}
-              </>
-            )
-          }
+          <Tabs value={tabExtra} onValueChange={setTabExtra} className="w-full">
+            <TabsList className="mb-4 w-full flex gap-2">
+              <TabsTrigger value="global">Global</TabsTrigger>
+              <TabsTrigger value="dimensiones">Dimensiones</TabsTrigger>
+            </TabsList>
+            <TabsContent value="global">
+              {datosExtra.length === 0 ? (
+                <div className="text-gray-500 py-4">No hay resultados Extralaborales.</div>
+              ) : (
+                <>
+                  <GraficaBarraSimple resumen={resumenExtra} titulo="Niveles Extralaborales" chartType={chartType} />
+                  {!soloGenerales && <TablaIndividual datos={datosExtra} tipo="extralaboral" />}
+                </>
+              )}
+            </TabsContent>
+            <TabsContent value="dimensiones">
+              {datosExtra.length === 0 ? (
+                <div className="text-gray-500 py-4">No hay datos para dimensiones.</div>
+              ) : (
+                <>
+                  <GraficaBarra resumen={promediosDimensionesExtra} titulo="Promedio de Puntaje Transformado por Dimensión" keyData="promedio" chartType={chartType} />
+                  {!soloGenerales && <TablaDimensiones datos={datosExtra} nombres={nombresExtra} />}
+                </>
+              )}
+            </TabsContent>
+          </Tabs>
         </TabsContent>
 
         {/* ---- GLOBAL A + EXTRA ---- */}


### PR DESCRIPTION
## Summary
- import `dimensionesExtralaboral` to use extralaboral dimension names
- track selected sub-tab for extralaboral results
- compute `promediosDimensionesExtra`
- add `TablaDimensiones` for per-employee extralaboral scores
- show nested tabs under Extralaboral for global and dimensional results

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6851fbcd54808331a4cf022e7e381435