### PR TITLE
Fix missing domain tables

### DIFF
--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -524,6 +524,48 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro, onBa
     );
   }
 
+  function TablaDominios({ datos, dominios, keyResultado }: { datos: any[]; dominios: string[]; keyResultado: string }) {
+    if (datos.length === 0)
+      return <div className="py-6 text-gray-400">No hay resultados de dominios para mostrar.</div>;
+
+    return (
+      <div className="overflow-x-auto">
+        <table className="w-full text-xs border mt-2">
+          <thead className="bg-cogent-blue text-white">
+            <tr>
+              <th>#</th>
+              <th>Empresa</th>
+              <th>Nombre</th>
+              {dominios.map((dom, idx) => (
+                <th key={idx}>{dom}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {datos.map((d, i) => (
+              <tr key={i} className="border-b">
+                <td>{i + 1}</td>
+                <td>{d.ficha?.empresa}</td>
+                <td>{d.ficha?.nombre}</td>
+                {dominios.map((dom, idx) => {
+                  let seccion = d[keyResultado]?.dominios?.[dom];
+                  if (Array.isArray(d[keyResultado]?.dominios)) {
+                    const item = d[keyResultado].dominios.find((x: any) => x.nombre === dom);
+                    seccion = item;
+                  }
+                  const valor = typeof seccion === "object"
+                    ? seccion.transformado ?? seccion.puntajeTransformado
+                    : d[keyResultado]?.puntajesDominio?.[dom];
+                  return <td key={idx}>{valor ?? ""}</td>;
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    );
+  }
+
   // ---- Render gráficos ----
   function GraficaBarra({
     resumen,
@@ -769,7 +811,22 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro, onBa
             <TabsContent value="dominios">
               {datosA.length === 0
                 ? <div className="text-gray-500 py-4">No hay datos para dominios.</div>
-                : <GraficaBarra resumen={promediosDominiosA} titulo="Promedio de Puntaje Transformado por Dominio" chartType={chartType} />
+                : (
+                  <>
+                    <GraficaBarra
+                      resumen={promediosDominiosA}
+                      titulo="Promedio de Puntaje Transformado por Dominio"
+                      chartType={chartType}
+                    />
+                    {!soloGenerales && (
+                      <TablaDominios
+                        datos={datosA}
+                        dominios={dominiosA}
+                        keyResultado="resultadoFormaA"
+                      />
+                    )}
+                  </>
+                )
               }
             </TabsContent>
             <TabsContent value="dimensiones">
@@ -818,7 +875,22 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro, onBa
             <TabsContent value="dominios">
               {datosB.length === 0
                 ? <div className="text-gray-500 py-4">No hay datos para dominios.</div>
-                : <GraficaBarra resumen={promediosDominiosB} titulo="Promedio de Puntaje Transformado por Dominio" chartType={chartType} />
+                : (
+                  <>
+                    <GraficaBarra
+                      resumen={promediosDominiosB}
+                      titulo="Promedio de Puntaje Transformado por Dominio"
+                      chartType={chartType}
+                    />
+                    {!soloGenerales && (
+                      <TablaDominios
+                        datos={datosB}
+                        dominios={dominiosB}
+                        keyResultado="resultadoFormaB"
+                      />
+                    )}
+                  </>
+                )
               }
             </TabsContent>
             <TabsContent value="dimensiones">


### PR DESCRIPTION
## Summary
- show per-domain tables in dashboard for Forms A and B
- add `TablaDominios` helper

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6852e2c5087c8331af56b4d560b921b5