### PR TITLE
Add company admin flow

### DIFF
--- a/src/components/AdminEmpresas.tsx
+++ b/src/components/AdminEmpresas.tsx
@@ -1,0 +1,48 @@
+import React, { useState } from "react";
+
+export default function AdminEmpresas({ empresas, credenciales, onAgregar }:{ empresas: string[]; credenciales: { usuario: string; empresa: string }[]; onAgregar: (nombre: string, usuario: string, password: string) => void; }) {
+  const [nombre, setNombre] = useState("");
+  const [usuario, setUsuario] = useState("");
+  const [password, setPassword] = useState("");
+
+  const handleAgregar = () => {
+    if (!nombre.trim() || !usuario.trim() || !password.trim()) return;
+    onAgregar(nombre.trim(), usuario.trim(), password.trim());
+    setNombre("");
+    setUsuario("");
+    setPassword("");
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="overflow-x-auto">
+        <table className="w-full text-xs border mt-2">
+          <thead className="bg-cogent-blue text-white">
+            <tr>
+              <th>#</th>
+              <th>Empresa</th>
+              <th>Usuario</th>
+            </tr>
+          </thead>
+          <tbody>
+            {credenciales.map((c, idx) => (
+              <tr key={idx} className="border-b">
+                <td className="px-2 py-1">{idx + 1}</td>
+                <td className="px-2 py-1">{c.empresa}</td>
+                <td className="px-2 py-1">{c.usuario}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div className="flex flex-wrap gap-2 items-center">
+        <input className="input flex-1" placeholder="Nombre empresa" value={nombre} onChange={(e)=>setNombre(e.target.value)} />
+        <input className="input flex-1" placeholder="Usuario" value={usuario} onChange={(e)=>setUsuario(e.target.value)} />
+        <input className="input flex-1" type="password" placeholder="Contraseña" value={password} onChange={(e)=>setPassword(e.target.value)} />
+        <button type="button" className="bg-cogent-blue text-white px-4 py-1 rounded-lg shadow" onClick={handleAgregar}>
+          Agregar
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -13,6 +13,7 @@ import TablaDimensiones from "@/components/TablaDimensiones";
 import GraficaBarra from "@/components/GraficaBarra";
 import GraficaBarraSimple from "@/components/GraficaBarraSimple";
 import GraficaBarraCategorias from "@/components/GraficaBarraCategorias";
+import AdminEmpresas from "@/components/AdminEmpresas";
 
 const nivelesRiesgo = [
   "Riesgo muy bajo",
@@ -25,6 +26,9 @@ const nivelesRiesgo = [
 type Props = {
   soloGenerales?: boolean;
   empresaFiltro?: string;
+  empresas?: string[];
+  credenciales?: { usuario: string; password: string; empresa: string }[];
+  onAgregarEmpresa?: (nombre: string, usuario: string, password: string) => void;
   onBack?: () => void;
 };
 
@@ -101,7 +105,7 @@ const categoriasFicha = [
 ] as const;
 
 
-export default function DashboardResultados({ soloGenerales, empresaFiltro, onBack }: Props) {
+export default function DashboardResultados({ soloGenerales, empresaFiltro, empresas: empresasConfig = [], credenciales = [], onAgregarEmpresa, onBack }: Props) {
   const [datos, setDatos] = useState<any[]>([]);
   const [empresaSeleccionada, setEmpresaSeleccionada] = useState(empresaFiltro || "todas");
   const [tab, setTab] = useState("general");
@@ -122,7 +126,7 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro, onBa
   }, []);
 
   // Empresas únicas (para filtro manual, psicóloga)
-  const empresas = Array.from(new Set(datos.map((d) => d.ficha?.empresa || "Sin empresa")));
+  const empresasResultados = Array.from(new Set(datos.map((d) => d.ficha?.empresa || "Sin empresa")));
 
   // Aplica el filtro según el rol
   const datosMostrados = datos.filter(
@@ -469,7 +473,7 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro, onBa
             className="input"
           >
             <option value="todas">Todas</option>
-            {empresas.map((e, idx) => (
+            {empresasResultados.map((e, idx) => (
               <option key={idx} value={e}>{e}</option>
             ))}
           </select>
@@ -502,6 +506,9 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro, onBa
         <TabsTrigger value="informe">Informe completo</TabsTrigger>
         {!soloGenerales && (
           <TabsTrigger value="admin">Eliminar encuestas</TabsTrigger>
+        )}
+        {!soloGenerales && (
+          <TabsTrigger value="empresas">Empresas</TabsTrigger>
         )}
       </TabsList>
 
@@ -840,6 +847,11 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro, onBa
                 </button>
               </>
             )}
+          </TabsContent>
+        )}
+        {!soloGenerales && (
+          <TabsContent value="empresas">
+            <AdminEmpresas empresas={empresasConfig} credenciales={credenciales} onAgregar={onAgregarEmpresa || (()=>{})} />
           </TabsContent>
         )}
       </Tabs>

--- a/src/components/FichaDatosGenerales.tsx
+++ b/src/components/FichaDatosGenerales.tsx
@@ -35,9 +35,8 @@ const tipoSalario = [
 ];
 
 export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Props) {
-  const [empresas, setEmpresas] = useState<string[]>(empresasIniciales);
+  const empresas = empresasIniciales;
   const [empresa, setEmpresa] = useState("");
-  const [nuevaEmpresa, setNuevaEmpresa] = useState("");
 
   const [datos, setDatos] = useState<any>({
     nombre: "",
@@ -67,15 +66,6 @@ export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Pr
   });
 
   const [error, setError] = useState<string>("");
-
-  const handleAgregarEmpresa = () => {
-    if (nuevaEmpresa.trim() && !empresas.includes(nuevaEmpresa.trim())) {
-      setEmpresas([...empresas, nuevaEmpresa.trim()]);
-      setEmpresa(nuevaEmpresa.trim());
-      setNuevaEmpresa("");
-      setDatos({ ...datos, empresa: nuevaEmpresa.trim() });
-    }
-  };
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
     const { name, value, type, checked } = e.target;
@@ -134,23 +124,6 @@ export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Pr
             <option key={i} value={em}>{em}</option>
           ))}
         </select>
-        <div className="flex gap-2">
-          <input
-            type="text"
-            placeholder="Agregar nueva empresa"
-            className="input flex-1"
-            value={nuevaEmpresa}
-            onChange={(e) => setNuevaEmpresa(e.target.value)}
-          />
-          <button
-            type="button"
-            className="bg-cogent-blue text-white px-3 rounded-lg shadow hover:bg-cogent-sky"
-            onClick={handleAgregarEmpresa}
-            disabled={!nuevaEmpresa.trim()}
-          >
-            +
-          </button>
-        </div>
       </div>
       {/* Nombre y cédula */}
       <div className="flex gap-4">

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -1,12 +1,13 @@
 import React, { useState } from "react";
-import usuarios from "../config/credentials.json";
+type Usuario = { usuario: string; password: string; rol: string; empresa?: string };
 
 type Props = {
+  usuarios: Usuario[];
   onLogin: (rol: "psicologa" | "dueno", empresa?: string) => void;
   onCancel?: () => void;
 };
 
-export default function Login({ onLogin, onCancel }: Props) {
+export default function Login({ usuarios, onLogin, onCancel }: Props) {
   const [usuario, setUsuario] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);


### PR DESCRIPTION
## Summary
- prevent adding new companies in the general form
- manage enterprises and credentials from dashboard
- load credentials and enterprises from `localStorage`
- allow psychologist to create company logins

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6853162f988083319ba2be452433f55b