### PR TITLE
Update font loading and Tailwind defaults

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@700&family=Open+Sans:wght@400&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=Poppins:wght@400&family=Roboto:wght@400&display=swap" rel="stylesheet">
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/logo_forma.png" />
     <link rel="apple-touch-icon" href="/logo_forma.png" />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -60,10 +60,10 @@ module.exports = {
   				'5': 'hsl(var(--chart-5))'
   			}
   		},
-  		fontFamily: {
-                        display: ['Inter', 'Nunito Sans', 'sans-serif'],
-                        sans: ['Roboto', 'sans-serif']
-  		},
+                fontFamily: {
+                        display: ['Montserrat', 'Inter', 'Nunito Sans', 'sans-serif'],
+                        sans: ['Montserrat', 'Roboto', 'sans-serif']
+                },
   		borderRadius: {
   			lg: 'var(--radius)',
   			md: 'calc(var(--radius) - 2px)',


### PR DESCRIPTION
## Summary
- load Montserrat 400-700 with optional Poppins/Roboto fallbacks
- set Montserrat as primary font in Tailwind

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68532dbb508c833187520424b97b4ba0