### PR TITLE
Update chart color arrays

### DIFF
--- a/src/components/GraficaBarra.tsx
+++ b/src/components/GraficaBarra.tsx
@@ -2,11 +2,11 @@ import React from "react";
 import { BarChart, Bar, PieChart, Pie, Cell, XAxis, YAxis, Tooltip, Legend, ResponsiveContainer, LabelList } from "recharts";
 
 const colorPorNivel = {
-  "Riesgo muy bajo": "#538DD4",
-  "Riesgo bajo": "#91CF50",
-  "Riesgo medio": "#FFFF00",
-  "Riesgo alto": "#FFA400",
-  "Riesgo muy alto": "#FF0000",
+  "Riesgo muy bajo": "#48C774",
+  "Riesgo bajo": "#2563EB",
+  "Riesgo medio": "#3B82F6",
+  "Riesgo alto": "#60A5FA",
+  "Riesgo muy alto": "#FF3B30",
 } as const;
 const nivelesRiesgo = Object.keys(colorPorNivel);
 

--- a/src/components/GraficaBarraCategorias.tsx
+++ b/src/components/GraficaBarraCategorias.tsx
@@ -1,7 +1,14 @@
 import React from "react";
 import { BarChart, Bar, PieChart, Pie, Cell, XAxis, YAxis, Tooltip, Legend, ResponsiveContainer } from "recharts";
 
-const coloresAzulFicha = ["#1e3a8a", "#2563eb", "#3b82f6", "#60a5fa", "#93c5fd", "#bfdbfe"];
+const coloresAzulFicha = [
+  "#48C774",
+  "#2563EB",
+  "#3B82F6",
+  "#60A5FA",
+  "#93C5FD",
+  "#FF3B30",
+];
 
 export default function GraficaBarraCategorias({
   datos,

--- a/src/components/GraficaBarraSimple.tsx
+++ b/src/components/GraficaBarraSimple.tsx
@@ -1,7 +1,13 @@
 import React from "react";
 import { BarChart, Bar, PieChart, Pie, Cell, XAxis, YAxis, Tooltip, Legend, ResponsiveContainer } from "recharts";
 
-const colores = ["#538DD4", "#91CF50", "#FFFF00", "#FFA400", "#FF0000"];
+const colores = [
+  "#48C774", // success
+  "#2563EB",
+  "#3B82F6",
+  "#60A5FA",
+  "#FF3B30", // error
+];
 
 export default function GraficaBarraSimple({
   resumen,

--- a/src/components/coloresDashboard.ts
+++ b/src/components/coloresDashboard.ts
@@ -1,1 +1,7 @@
-export const colores = ["#2a57d3", "#1db2f5", "#ffbc1c", "#f2600e", "#d7263d"];
+export const colores = [
+  "#48C774",
+  "#2563EB",
+  "#3B82F6",
+  "#60A5FA",
+  "#FF3B30",
+];


### PR DESCRIPTION
## Summary
- use success and error palette for risk charts
- adjust blue gradients for category charts and dashboard

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68532dc2187c83318bf0a207fe1ad804