### PR TITLE
Update wrappers to new color variables

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -135,7 +135,7 @@ export default function App() {
   // Vista Home
   if (step === "inicio") {
     return (
-      <div className="flex flex-col items-center justify-center min-h-screen gap-4 bg-gray-50">
+      <div className="flex flex-col items-center justify-center min-h-screen gap-4 bg-[var(--background-main)]">
         <img src={logoTexto} alt="COGENT" className="w-60 mb-2" />
         <button
           className="bg-cogent-blue text-white font-bold px-6 py-3 rounded-xl shadow hover:bg-cogent-sky mb-2"
@@ -182,7 +182,7 @@ export default function App() {
 
   // Flujo de encuesta
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-gray-100">
+    <div className="min-h-screen flex flex-col items-center justify-center bg-[var(--background-main)]">
       {step === "consent" && (
         <Consentimiento onAceptar={() => setStep("selector")} />
       )}
@@ -264,7 +264,7 @@ export default function App() {
         />
       )}
       {step === "final" && (
-        <div className="p-8 bg-white rounded-xl shadow-md text-cogent-navy font-bold text-2xl flex flex-col items-center gap-4">
+        <div className="p-8 bg-white rounded-xl shadow-md text-[var(--text-main)] font-bold text-2xl flex flex-col items-center gap-4">
           <div>
             ¡Encuesta completada!<br />
             Gracias por tu participación.

--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -460,8 +460,8 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro, empr
   // ---- Render tablas individuales (solo para psicóloga) ----
   // ---- Pestañas ----
   return (
-    <div className="max-w-6xl mx-auto bg-white p-6 md:p-8 rounded-2xl shadow-xl mt-8 flex flex-col gap-8">
-        <h2 className="text-2xl md:text-3xl font-bold text-cogent-blue mb-2 md:mb-4">Dashboard de Resultados</h2>
+    <div className="max-w-6xl mx-auto bg-[var(--background-main)] p-6 md:p-8 rounded-2xl shadow-xl mt-8 flex flex-col gap-8">
+        <h2 className="text-2xl md:text-3xl font-bold text-[var(--text-main)] mb-2 md:mb-4">Dashboard de Resultados</h2>
 
         {/* Filtro empresa, solo para psicóloga */}
         {!empresaFiltro && (
@@ -564,7 +564,7 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro, empr
             </TabsList>
             <TabsContent value="global">
               {datosA.length === 0
-                ? <div className="text-gray-500 py-4">No hay resultados de Forma A.</div>
+                ? <div className="text-[var(--gray-medium)] py-4">No hay resultados de Forma A.</div>
                 : (
                   <>
                     <GraficaBarraSimple resumen={resumenA} titulo="Niveles de Forma A" chartType={chartType} />
@@ -575,7 +575,7 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro, empr
             </TabsContent>
             <TabsContent value="dominios">
               {datosA.length === 0
-                ? <div className="text-gray-500 py-4">No hay datos para dominios.</div>
+                ? <div className="text-[var(--gray-medium)] py-4">No hay datos para dominios.</div>
                 : (
                   <>
                     <GraficaBarra
@@ -596,7 +596,7 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro, empr
             </TabsContent>
             <TabsContent value="dimensiones">
               {datosA.length === 0
-                ? <div className="text-gray-500 py-4">No hay datos para dimensiones.</div>
+                ? <div className="text-[var(--gray-medium)] py-4">No hay datos para dimensiones.</div>
                 : (
                   <>
                     <GraficaBarra
@@ -628,7 +628,7 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro, empr
             </TabsList>
             <TabsContent value="global">
               {datosB.length === 0
-                ? <div className="text-gray-500 py-4">No hay resultados de Forma B.</div>
+                ? <div className="text-[var(--gray-medium)] py-4">No hay resultados de Forma B.</div>
                 : (
                   <>
                     <GraficaBarraSimple resumen={resumenB} titulo="Niveles de Forma B" chartType={chartType} />
@@ -639,7 +639,7 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro, empr
             </TabsContent>
             <TabsContent value="dominios">
               {datosB.length === 0
-                ? <div className="text-gray-500 py-4">No hay datos para dominios.</div>
+                ? <div className="text-[var(--gray-medium)] py-4">No hay datos para dominios.</div>
                 : (
                   <>
                     <GraficaBarra
@@ -660,7 +660,7 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro, empr
             </TabsContent>
             <TabsContent value="dimensiones">
               {datosB.length === 0
-                ? <div className="text-gray-500 py-4">No hay datos para dimensiones.</div>
+                ? <div className="text-[var(--gray-medium)] py-4">No hay datos para dimensiones.</div>
                 : (
                   <>
                     <GraficaBarra
@@ -691,7 +691,7 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro, empr
             </TabsList>
             <TabsContent value="global">
               {datosExtra.length === 0
-                ? <div className="text-gray-500 py-4">No hay resultados Extralaborales.</div>
+                ? <div className="text-[var(--gray-medium)] py-4">No hay resultados Extralaborales.</div>
                 : (
                   <>
                     <GraficaBarraSimple resumen={resumenExtra} titulo="Niveles Extralaborales" chartType={chartType} />
@@ -702,7 +702,7 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro, empr
             </TabsContent>
             <TabsContent value="dimensiones">
               {datosExtra.length === 0
-                ? <div className="text-gray-500 py-4">No hay datos para dimensiones.</div>
+                ? <div className="text-[var(--gray-medium)] py-4">No hay datos para dimensiones.</div>
                 : (
                   <>
                     <GraficaBarra
@@ -736,7 +736,7 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro, empr
             </TabsList>
             <TabsContent value="A">
               {datosGlobalAE.length === 0 ? (
-                <div className="text-gray-500 py-4">No hay resultados Globales A.</div>
+                <div className="text-[var(--gray-medium)] py-4">No hay resultados Globales A.</div>
               ) : (
                 <>
                   <GraficaBarraSimple resumen={resumenGlobalAE} titulo="Niveles Global A + Extra" />
@@ -746,7 +746,7 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro, empr
             </TabsContent>
             <TabsContent value="B">
               {datosGlobalBE.length === 0 ? (
-                <div className="text-gray-500 py-4">No hay resultados Globales B.</div>
+                <div className="text-[var(--gray-medium)] py-4">No hay resultados Globales B.</div>
               ) : (
                 <>
                   <GraficaBarraSimple resumen={resumenGlobalBE} titulo="Niveles Global B + Extra" />
@@ -760,7 +760,7 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro, empr
         {/* ---- ESTRÉS ---- */}
         <TabsContent value="estres">
           {datosEstres.length === 0
-            ? <div className="text-gray-500 py-4">No hay resultados de Estrés.</div>
+            ? <div className="text-[var(--gray-medium)] py-4">No hay resultados de Estrés.</div>
             : (
               <>
                 <GraficaBarraSimple resumen={resumenEstres} titulo="Niveles de Estrés" chartType={chartType} />
@@ -772,7 +772,7 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro, empr
         {/* ---- INFORME COMPLETO ---- */}
         <TabsContent value="informe">
           {datosInforme.length === 0 ? (
-            <div className="text-gray-500 py-4">No hay datos para mostrar.</div>
+            <div className="text-[var(--gray-medium)] py-4">No hay datos para mostrar.</div>
           ) : (
             <div className="overflow-auto max-h-96">
               <table className="w-full text-xs border mt-2">
@@ -803,7 +803,7 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro, empr
         {!soloGenerales && (
           <TabsContent value="admin">
             {datos.length === 0 ? (
-              <div className="text-gray-500 py-4">No hay encuestas almacenadas.</div>
+              <div className="text-[var(--gray-medium)] py-4">No hay encuestas almacenadas.</div>
             ) : (
               <>
                 <div className="overflow-x-auto">

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -26,10 +26,10 @@ export default function Login({ usuarios, onLogin, onCancel }: Props) {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100">
+    <div className="min-h-screen flex items-center justify-center bg-[var(--background-main)]">
       <form onSubmit={handleSubmit} className="bg-white p-8 rounded-xl shadow-xl flex flex-col gap-4 min-w-[300px]">
         <img src={logoTexto} alt="COGENT" className="w-48 mx-auto" />
-        <h2 className="text-2xl font-bold text-cogent-blue mb-2 text-center">Acceso a resultados</h2>
+        <h2 className="text-2xl font-bold text-[var(--text-main)] mb-2 text-center">Acceso a resultados</h2>
         <input
           className="input"
           placeholder="Usuario"
@@ -50,13 +50,13 @@ export default function Login({ usuarios, onLogin, onCancel }: Props) {
         {onCancel && (
           <button
             type="button"
-            className="text-gray-500 text-sm hover:underline"
+            className="text-[var(--gray-medium)] text-sm hover:underline"
             onClick={onCancel}
           >
             Volver al inicio
           </button>
         )}
-        <div className="text-xs mt-2 text-gray-400">
+        <div className="text-xs mt-2 text-[var(--gray-medium)]">
           {usuarios.map((u) => (
             <div key={u.usuario}>
               <b>{u.rol === "psicologa" ? "Psicóloga" : u.empresa}</b>: {u.usuario}

--- a/src/index.css
+++ b/src/index.css
@@ -28,6 +28,9 @@
     --chart-3: 197 37% 24%;
     --chart-4: 43 74% 66%;
     --chart-5: 27 87% 67%;
+    --background-main: #F8F9FA;
+    --text-main: #1B264F;
+    --gray-medium: #6B7280;
     --radius: 0.5rem
   }
   .dark {
@@ -55,6 +58,9 @@
     --chart-3: 30 80% 55%;
     --chart-4: 280 65% 60%;
     --chart-5: 340 75% 55%
+    --background-main: #111827;
+    --text-main: #F3F4F6;
+    --gray-medium: #9CA3AF;
   }
 }
 


### PR DESCRIPTION
## Summary
- update wrapper backgrounds to use `--background-main`
- apply `--text-main` and `--gray-medium` for headings and messages
- define new CSS variables for colors

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68532dc4421883319d6bb7c2fbd6df58