### PR TITLE
Enhance question blocks style

### DIFF
--- a/src/components/BloquesDePreguntas.tsx
+++ b/src/components/BloquesDePreguntas.tsx
@@ -108,10 +108,26 @@ export default function BloquesDePreguntas({ bloques, preguntas, onFinish }: Pro
 
   // Render
   return (
-    <div className="max-w-2xl bg-white rounded-2xl shadow-xl p-8 flex flex-col gap-4">
-      <h3 className="font-bold text-primary-main text-xl mb-2">
-        {bloque.enunciado}
-      </h3>
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-b from-[#F4F8FA] to-[#FFFFFF] relative overflow-hidden px-2">
+      <svg
+        className="absolute left-0 top-0 opacity-10 w-[320px] h-[320px] -z-10"
+        viewBox="0 0 320 320"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle cx="160" cy="160" r="140" fill="url(#grad1)" />
+        <defs>
+          <linearGradient id="grad1" x1="60" y1="30" x2="260" y2="260" gradientUnits="userSpaceOnUse">
+            <stop stopColor="#2EC4FF" />
+            <stop offset="1" stopColor="#005DFF" />
+          </linearGradient>
+        </defs>
+      </svg>
+
+      <div className="bg-white rounded-3xl shadow-xl p-8 md:p-12 w-full max-w-2xl mx-auto animate-fadeIn flex flex-col gap-4">
+        <h3 className="font-bold text-[#132045] text-xl md:text-2xl mb-2 text-center font-montserrat">
+          {bloque.enunciado}
+        </h3>
       {preguntasBloque.map((preg, i) => {
   const idx = bloque.preguntas[0] + i;
   return (
@@ -178,6 +194,7 @@ export default function BloquesDePreguntas({ bloques, preguntas, onFinish }: Pro
           {bloqueActual === bloques.length - 1 ? "Finalizar" : "Siguiente"}
         </button>
       </div>
+    </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- restyle question blocks section to match data sheet layout
- use home page gradient button styling

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6853727ac16c8331988e79b69133687b