### PR TITLE
Remove padding from TabsList

### DIFF
--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -12,7 +12,7 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      "inline-flex h-9 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground",
+      "flex items-center justify-center rounded-lg bg-muted text-muted-foreground",
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary
- allow padding override on `TabsList`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_68538e49bc208331a8bfa330ace8af23