### PR TITLE
Refactor dashboard tabs

### DIFF
--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -12,8 +12,9 @@ import TablaDominios from "@/components/TablaDominios";
 import TablaDimensiones from "@/components/TablaDimensiones";
 import GraficaBarra from "@/components/GraficaBarra";
 import GraficaBarraSimple from "@/components/GraficaBarraSimple";
-import GraficaBarraCategorias from "@/components/GraficaBarraCategorias";
 import AdminEmpresas from "@/components/AdminEmpresas";
+import GeneralResultsTabs from "@/components/dashboard/GeneralResultsTabs";
+import FormaTabs from "@/components/dashboard/FormaTabs";
 import LogoCogent from "/logo_forma.png";
 import { FileDown, FileText, Home as HomeIcon } from "lucide-react";
 
@@ -531,180 +532,62 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro, empr
 
         {/* ---- GENERAL ---- */}
         <TabsContent value="general">
-          <Tabs value={tabGeneral} onValueChange={setTabGeneral} className="w-full">
-
-            <TabsList className="mb-6 py-2 px-4 scroll-pl-4 w-full flex gap-2 overflow-x-auto whitespace-nowrap">
-
-              <TabsTrigger className={tabPill} value="resumen">Resultados</TabsTrigger>
-              <TabsTrigger className={tabPill} value="ficha">Ficha técnica</TabsTrigger>
-            </TabsList>
-            <TabsContent value="resumen">
-              <div className="grid md:grid-cols-2 gap-4">
-                {datosA.length > 0 && (
-                  <GraficaBarraSimple resumen={resumenA} titulo="Niveles de Forma A" chartType={chartType} />
-                )}
-                {datosB.length > 0 && (
-                  <GraficaBarraSimple resumen={resumenB} titulo="Niveles de Forma B" chartType={chartType} />
-                )}
-                {datosExtra.length > 0 && (
-                  <GraficaBarraSimple resumen={resumenExtra} titulo="Niveles Extralaborales" chartType={chartType} />
-                )}
-                {datosEstres.length > 0 && (
-                  <GraficaBarraSimple resumen={resumenEstres} titulo="Niveles de Estrés" chartType={chartType} />
-                )}
-              </div>
-            </TabsContent>
-            <TabsContent value="ficha">
-              <Tabs value={categoriaFicha} onValueChange={setCategoriaFicha} className="w-full">
-
-                <TabsList className="mb-6 py-2 pl-4 pr-4 scroll-pl-4 w-full flex gap-2 overflow-x-auto whitespace-nowrap">
-
-                  {categoriasFicha.map((c) => (
-                    <TabsTrigger className={tabPill} key={c.key} value={c.key}>{c.label}</TabsTrigger>
-                  ))}
-                </TabsList>
-                {categoriasFicha.map((c) => (
-                  <TabsContent key={c.key} value={c.key}>
-                    <div className="grid gap-4">
-                      <GraficaBarraCategorias datos={fichaConteosGlobal[c.key]} titulo={c.label} chartType={chartType} />
-                    </div>
-                  </TabsContent>
-                ))}
-              </Tabs>
-            </TabsContent>
-          </Tabs>
+          <GeneralResultsTabs
+            value={tabGeneral}
+            onChange={setTabGeneral}
+            tabClass={tabPill}
+            chartType={chartType}
+            datosA={datosA}
+            datosB={datosB}
+            datosExtra={datosExtra}
+            datosEstres={datosEstres}
+            resumenA={resumenA}
+            resumenB={resumenB}
+            resumenExtra={resumenExtra}
+            resumenEstres={resumenEstres}
+            categoriaFicha={categoriaFicha}
+            onCategoriaChange={setCategoriaFicha}
+            categoriasFicha={categoriasFicha}
+            fichaConteos={fichaConteosGlobal}
+          />
         </TabsContent>
 
         {/* ---- FORMA A ---- */}
         <TabsContent value="formaA">
-          <Tabs value={tabIntra} onValueChange={setTabIntra} className="w-full">
-
-            <TabsList className="mb-6 py-2 px-4 scroll-pl-4 w-full flex gap-2 overflow-x-auto whitespace-nowrap">
-
-              <TabsTrigger className={tabPill} value="global">Global</TabsTrigger>
-              <TabsTrigger className={tabPill} value="dominios">Por Dominio</TabsTrigger>
-              <TabsTrigger className={tabPill} value="dimensiones">Por Dimensión</TabsTrigger>
-            </TabsList>
-            <TabsContent value="global">
-              {datosA.length === 0
-                ? <div className="text-[var(--gray-medium)] py-4">No hay resultados de Forma A.</div>
-                : (
-                  <>
-                    <GraficaBarraSimple resumen={resumenA} titulo="Niveles de Forma A" chartType={chartType} />
-                    {!soloGenerales && <TablaIndividual datos={datosA} tipo="formaA" />}
-                  </>
-                )
-              }
-            </TabsContent>
-            <TabsContent value="dominios">
-              {datosA.length === 0
-                ? <div className="text-[var(--gray-medium)] py-4">No hay datos para dominios.</div>
-                : (
-                  <>
-                    <GraficaBarra
-                      resumen={promediosDominiosA}
-                      titulo="Promedio de Puntaje Transformado por Dominio"
-                      chartType={chartType}
-                    />
-                    {!soloGenerales && (
-                      <TablaDominios
-                        datos={datosA}
-                        dominios={dominiosA}
-                        keyResultado="resultadoFormaA"
-                      />
-                    )}
-                  </>
-                )
-              }
-            </TabsContent>
-            <TabsContent value="dimensiones">
-              {datosA.length === 0
-                ? <div className="text-[var(--gray-medium)] py-4">No hay datos para dimensiones.</div>
-                : (
-                  <>
-                    <GraficaBarra
-                      resumen={promediosDimensionesA}
-                      titulo="Promedio de Puntaje Transformado por Dimensión"
-                      chartType={chartType}
-                    />
-                    {!soloGenerales && (
-                      <TablaDimensiones
-                        datos={datosA}
-                        dimensiones={dimensionesA}
-                        keyResultado="resultadoFormaA"
-                      />
-                    )}
-                  </>
-                )
-              }
-            </TabsContent>
-          </Tabs>
+          <FormaTabs
+            value={tabIntra}
+            onChange={setTabIntra}
+            datos={datosA}
+            resumen={resumenA}
+            promediosDominios={promediosDominiosA}
+            promediosDimensiones={promediosDimensionesA}
+            dominios={dominiosA}
+            dimensiones={dimensionesA}
+            chartType={chartType}
+            tabClass={tabPill}
+            soloGenerales={soloGenerales}
+            tipo="formaA"
+            keyResultado="resultadoFormaA"
+          />
         </TabsContent>
 
         {/* ---- FORMA B ---- */}
         <TabsContent value="formaB">
-          <Tabs value={tabIntra} onValueChange={setTabIntra} className="w-full">
-
-            <TabsList className="mb-6 py-2 px-4 scroll-pl-4 w-full flex gap-2 overflow-x-auto whitespace-nowrap">
-
-              <TabsTrigger className={tabPill} value="global">Global</TabsTrigger>
-              <TabsTrigger className={tabPill} value="dominios">Por Dominio</TabsTrigger>
-              <TabsTrigger className={tabPill} value="dimensiones">Por Dimensión</TabsTrigger>
-            </TabsList>
-            <TabsContent value="global">
-              {datosB.length === 0
-                ? <div className="text-[var(--gray-medium)] py-4">No hay resultados de Forma B.</div>
-                : (
-                  <>
-                    <GraficaBarraSimple resumen={resumenB} titulo="Niveles de Forma B" chartType={chartType} />
-                    {!soloGenerales && <TablaIndividual datos={datosB} tipo="formaB" />}
-                  </>
-                )
-              }
-            </TabsContent>
-            <TabsContent value="dominios">
-              {datosB.length === 0
-                ? <div className="text-[var(--gray-medium)] py-4">No hay datos para dominios.</div>
-                : (
-                  <>
-                    <GraficaBarra
-                      resumen={promediosDominiosB}
-                      titulo="Promedio de Puntaje Transformado por Dominio"
-                      chartType={chartType}
-                    />
-                    {!soloGenerales && (
-                      <TablaDominios
-                        datos={datosB}
-                        dominios={dominiosB}
-                        keyResultado="resultadoFormaB"
-                      />
-                    )}
-                  </>
-                )
-              }
-            </TabsContent>
-            <TabsContent value="dimensiones">
-              {datosB.length === 0
-                ? <div className="text-[var(--gray-medium)] py-4">No hay datos para dimensiones.</div>
-                : (
-                  <>
-                    <GraficaBarra
-                      resumen={promediosDimensionesB}
-                      titulo="Promedio de Puntaje Transformado por Dimensión"
-                      chartType={chartType}
-                    />
-                    {!soloGenerales && (
-                      <TablaDimensiones
-                        datos={datosB}
-                        dimensiones={dimensionesB}
-                        keyResultado="resultadoFormaB"
-                      />
-                    )}
-                  </>
-                )
-              }
-            </TabsContent>
-          </Tabs>
+          <FormaTabs
+            value={tabIntra}
+            onChange={setTabIntra}
+            datos={datosB}
+            resumen={resumenB}
+            promediosDominios={promediosDominiosB}
+            promediosDimensiones={promediosDimensionesB}
+            dominios={dominiosB}
+            dimensiones={dimensionesB}
+            chartType={chartType}
+            tabClass={tabPill}
+            soloGenerales={soloGenerales}
+            tipo="formaB"
+            keyResultado="resultadoFormaB"
+          />
         </TabsContent>
 
         {/* ---- EXTRALABORAL ---- */}

--- a/src/components/dashboard/FichaTecnicaTabs.tsx
+++ b/src/components/dashboard/FichaTecnicaTabs.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import GraficaBarraCategorias from "@/components/GraficaBarraCategorias";
+
+export type CategoriaFicha = { key: string; label: string };
+
+export default function FichaTecnicaTabs({
+  categorias,
+  categoria,
+  onChange,
+  conteos,
+  chartType,
+  tabClass,
+}: {
+  categorias: CategoriaFicha[];
+  categoria: string;
+  onChange: (value: string) => void;
+  conteos: Record<string, any[]>;
+  chartType: "bar" | "histogram" | "pie";
+  tabClass: string;
+}) {
+  return (
+    <Tabs value={categoria} onValueChange={onChange} className="w-full">
+      <TabsList className="mb-6 py-2 pl-4 pr-4 scroll-pl-4 w-full flex gap-2 overflow-x-auto whitespace-nowrap">
+        {categorias.map((c) => (
+          <TabsTrigger className={tabClass} key={c.key} value={c.key}>
+            {c.label}
+          </TabsTrigger>
+        ))}
+      </TabsList>
+      {categorias.map((c) => (
+        <TabsContent key={c.key} value={c.key}>
+          <div className="grid gap-4">
+            <GraficaBarraCategorias
+              datos={conteos[c.key]}
+              titulo={c.label}
+              chartType={chartType}
+            />
+          </div>
+        </TabsContent>
+      ))}
+    </Tabs>
+  );
+}

--- a/src/components/dashboard/FormaTabs.tsx
+++ b/src/components/dashboard/FormaTabs.tsx
@@ -1,0 +1,105 @@
+import React from "react";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import GraficaBarraSimple from "@/components/GraficaBarraSimple";
+import GraficaBarra from "@/components/GraficaBarra";
+import TablaIndividual from "@/components/TablaIndividual";
+import TablaDominios from "@/components/TablaDominios";
+import TablaDimensiones from "@/components/TablaDimensiones";
+
+export default function FormaTabs({
+  value,
+  onChange,
+  datos,
+  resumen,
+  promediosDominios,
+  promediosDimensiones,
+  dominios,
+  dimensiones,
+  chartType,
+  tabClass,
+  soloGenerales,
+  tipo,
+  keyResultado,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  datos: any[];
+  resumen: any[];
+  promediosDominios: any[];
+  promediosDimensiones: any[];
+  dominios: string[];
+  dimensiones: string[];
+  chartType: "bar" | "histogram" | "pie";
+  tabClass: string;
+  soloGenerales?: boolean;
+  tipo: "formaA" | "formaB";
+  keyResultado: string;
+}) {
+  return (
+    <Tabs value={value} onValueChange={onChange} className="w-full">
+      <TabsList className="mb-6 py-2 px-4 scroll-pl-4 w-full flex gap-2 overflow-x-auto whitespace-nowrap">
+        <TabsTrigger className={tabClass} value="global">
+          Global
+        </TabsTrigger>
+        <TabsTrigger className={tabClass} value="dominios">
+          Por Dominio
+        </TabsTrigger>
+        <TabsTrigger className={tabClass} value="dimensiones">
+          Por Dimensión
+        </TabsTrigger>
+      </TabsList>
+      <TabsContent value="global">
+        {datos.length === 0 ? (
+          <div className="text-[var(--gray-medium)] py-4">
+            No hay resultados de {tipo === "formaA" ? "Forma A" : "Forma B"}.
+          </div>
+        ) : (
+          <>
+            <GraficaBarraSimple
+              resumen={resumen}
+              titulo={`Niveles de ${tipo === "formaA" ? "Forma A" : "Forma B"}`}
+              chartType={chartType}
+            />
+            {!soloGenerales && <TablaIndividual datos={datos} tipo={tipo} />}
+          </>
+        )}
+      </TabsContent>
+      <TabsContent value="dominios">
+        {datos.length === 0 ? (
+          <div className="text-[var(--gray-medium)] py-4">No hay datos para dominios.</div>
+        ) : (
+          <>
+            <GraficaBarra
+              resumen={promediosDominios}
+              titulo="Promedio de Puntaje Transformado por Dominio"
+              chartType={chartType}
+            />
+            {!soloGenerales && (
+              <TablaDominios datos={datos} dominios={dominios} keyResultado={keyResultado} />
+            )}
+          </>
+        )}
+      </TabsContent>
+      <TabsContent value="dimensiones">
+        {datos.length === 0 ? (
+          <div className="text-[var(--gray-medium)] py-4">No hay datos para dimensiones.</div>
+        ) : (
+          <>
+            <GraficaBarra
+              resumen={promediosDimensiones}
+              titulo="Promedio de Puntaje Transformado por Dimensión"
+              chartType={chartType}
+            />
+            {!soloGenerales && (
+              <TablaDimensiones
+                datos={datos}
+                dimensiones={dimensiones}
+                keyResultado={keyResultado}
+              />
+            )}
+          </>
+        )}
+      </TabsContent>
+    </Tabs>
+  );
+}

--- a/src/components/dashboard/GeneralResultsTabs.tsx
+++ b/src/components/dashboard/GeneralResultsTabs.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import GraficaBarraSimple from "@/components/GraficaBarraSimple";
+import FichaTecnicaTabs, { CategoriaFicha } from "./FichaTecnicaTabs";
+
+export default function GeneralResultsTabs({
+  value,
+  onChange,
+  tabClass,
+  chartType,
+  datosA,
+  datosB,
+  datosExtra,
+  datosEstres,
+  resumenA,
+  resumenB,
+  resumenExtra,
+  resumenEstres,
+  categoriaFicha,
+  onCategoriaChange,
+  categoriasFicha,
+  fichaConteos,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  tabClass: string;
+  chartType: "bar" | "histogram" | "pie";
+  datosA: any[];
+  datosB: any[];
+  datosExtra: any[];
+  datosEstres: any[];
+  resumenA: any[];
+  resumenB: any[];
+  resumenExtra: any[];
+  resumenEstres: any[];
+  categoriaFicha: string;
+  onCategoriaChange: (v: string) => void;
+  categoriasFicha: CategoriaFicha[];
+  fichaConteos: Record<string, any[]>;
+}) {
+  return (
+    <Tabs value={value} onValueChange={onChange} className="w-full">
+      <TabsList className="mb-6 py-2 px-4 scroll-pl-4 w-full flex gap-2 overflow-x-auto whitespace-nowrap">
+        <TabsTrigger className={tabClass} value="resumen">
+          Resultados
+        </TabsTrigger>
+        <TabsTrigger className={tabClass} value="ficha">
+          Ficha técnica
+        </TabsTrigger>
+      </TabsList>
+      <TabsContent value="resumen">
+        <div className="grid md:grid-cols-2 gap-4">
+          {datosA.length > 0 && (
+            <GraficaBarraSimple
+              resumen={resumenA}
+              titulo="Niveles de Forma A"
+              chartType={chartType}
+            />
+          )}
+          {datosB.length > 0 && (
+            <GraficaBarraSimple
+              resumen={resumenB}
+              titulo="Niveles de Forma B"
+              chartType={chartType}
+            />
+          )}
+          {datosExtra.length > 0 && (
+            <GraficaBarraSimple
+              resumen={resumenExtra}
+              titulo="Niveles Extralaborales"
+              chartType={chartType}
+            />
+          )}
+          {datosEstres.length > 0 && (
+            <GraficaBarraSimple
+              resumen={resumenEstres}
+              titulo="Niveles de Estrés"
+              chartType={chartType}
+            />
+          )}
+        </div>
+      </TabsContent>
+      <TabsContent value="ficha">
+        <FichaTecnicaTabs
+          categorias={categoriasFicha}
+          categoria={categoriaFicha}
+          onChange={onCategoriaChange}
+          conteos={fichaConteos}
+          chartType={chartType}
+          tabClass={tabClass}
+        />
+      </TabsContent>
+    </Tabs>
+  );
+}


### PR DESCRIPTION
## Summary
- split DashboardResultados into small components
- create `GeneralResultsTabs`, `FormaTabs` and `FichaTecnicaTabs`
- update Dashboard to use the new components

## Testing
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68538f955534833199a9931269933151