### PR TITLE
Adjust table styling to match cogent brand

### DIFF
--- a/src/components/AdminEmpresas.tsx
+++ b/src/components/AdminEmpresas.tsx
@@ -16,8 +16,8 @@ export default function AdminEmpresas({ empresas, credenciales, onAgregar }:{ em
   return (
     <div className="flex flex-col gap-4">
       <div className="overflow-x-auto">
-        <table className="w-full text-xs border mt-2">
-          <thead className="bg-primary-main text-white">
+        <table className="w-full text-xs border mt-2 rounded-lg overflow-hidden font-montserrat text-[#172349]">
+          <thead className="bg-gradient-to-r from-[#2EC4FF] to-[#005DFF] text-white font-semibold">
             <tr>
               <th>#</th>
               <th>Empresa</th>

--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -687,8 +687,8 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro, empr
             <div className="text-[var(--gray-medium)] py-4">No hay datos para mostrar.</div>
           ) : (
             <div className="overflow-auto max-h-96">
-              <table className="w-full text-xs border mt-2">
-                <thead className="bg-primary-main text-white">
+              <table className="w-full text-xs border mt-2 rounded-lg overflow-hidden font-montserrat text-[#172349]">
+                <thead className="bg-gradient-to-r from-[#2EC4FF] to-[#005DFF] text-white font-semibold">
                   <tr>
                     {allHeaders.map((h, idx) => (
                       <th key={idx} className="px-2 py-1">
@@ -719,8 +719,8 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro, empr
             ) : (
               <>
                 <div className="overflow-x-auto">
-                  <table className="w-full text-xs border mt-2">
-                    <thead className="bg-primary-main text-white">
+                  <table className="w-full text-xs border mt-2 rounded-lg overflow-hidden font-montserrat text-[#172349]">
+                    <thead className="bg-gradient-to-r from-[#2EC4FF] to-[#005DFF] text-white font-semibold">
                       <tr>
                         <th></th>
                         <th>#</th>

--- a/src/components/TablaDimensiones.tsx
+++ b/src/components/TablaDimensiones.tsx
@@ -6,8 +6,8 @@ export default function TablaDimensiones({ datos, dimensiones, keyResultado }: {
   }
   return (
     <div className="overflow-x-auto">
-      <table className="w-full text-xs border mt-2">
-        <thead className="bg-primary-main text-white">
+      <table className="w-full text-xs border mt-2 rounded-lg overflow-hidden font-montserrat text-[#172349]">
+        <thead className="bg-gradient-to-r from-[#2EC4FF] to-[#005DFF] text-white font-semibold">
           <tr>
             <th>#</th>
             <th>Empresa</th>

--- a/src/components/TablaDominios.tsx
+++ b/src/components/TablaDominios.tsx
@@ -6,8 +6,8 @@ export default function TablaDominios({ datos, dominios, keyResultado }: { datos
   }
   return (
     <div className="overflow-x-auto">
-      <table className="w-full text-xs border mt-2">
-        <thead className="bg-primary-main text-white">
+      <table className="w-full text-xs border mt-2 rounded-lg overflow-hidden font-montserrat text-[#172349]">
+        <thead className="bg-gradient-to-r from-[#2EC4FF] to-[#005DFF] text-white font-semibold">
           <tr>
             <th>#</th>
             <th>Empresa</th>

--- a/src/components/TablaIndividual.tsx
+++ b/src/components/TablaIndividual.tsx
@@ -6,8 +6,8 @@ export default function TablaIndividual({ datos, tipo }: { datos: any[]; tipo: s
   }
   return (
     <div className="overflow-x-auto">
-      <table className="w-full text-xs border mt-2">
-        <thead className="bg-primary-main text-white">
+      <table className="w-full text-xs border mt-2 rounded-lg overflow-hidden font-montserrat text-[#172349]">
+        <thead className="bg-gradient-to-r from-[#2EC4FF] to-[#005DFF] text-white font-semibold">
           <tr>
             <th>#</th>
             <th>Empresa</th>


### PR DESCRIPTION
## Summary
- make data table headers use home page gradient and fonts
- round table corners and set text color for consistency with the landing page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685453c774f083318b7a299155ef21a9