### PR TITLE
Add editable credentials table

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -80,6 +80,23 @@ export default function App() {
     setCredenciales([...credencialesBase, ...extras]);
   };
 
+  const editarEmpresa = (
+    empresa: string,
+    usuario: string,
+    password: string
+  ) => {
+    const extras = JSON.parse(localStorage.getItem("credencialesCogent") || "[]");
+    const idx = extras.findIndex((c: any) => c.empresa === empresa);
+    if (idx !== -1) {
+      extras[idx].usuario = usuario;
+      extras[idx].password = password;
+    } else {
+      extras.push({ usuario, password, rol: "dueno", empresa });
+    }
+    localStorage.setItem("credencialesCogent", JSON.stringify(extras));
+    setCredenciales([...credencialesBase, ...extras]);
+  };
+
   // Cuando finaliza la encuesta (luego del bloque de estrés)
   useEffect(() => {
     if (step === "final") {
@@ -165,6 +182,7 @@ export default function App() {
         empresas={empresasIniciales}
         credenciales={credenciales.filter((c) => c.rol === "dueno")}
         onAgregarEmpresa={agregarEmpresa}
+        onEditarEmpresa={editarEmpresa}
         onBack={() => setStep("inicio")}
       />
     );

--- a/src/components/AdminEmpresas.tsx
+++ b/src/components/AdminEmpresas.tsx
@@ -1,9 +1,22 @@
 import React, { useState } from "react";
 
-export default function AdminEmpresas({ empresas, credenciales, onAgregar }:{ empresas: string[]; credenciales: { usuario: string; empresa: string }[]; onAgregar: (nombre: string, usuario: string, password: string) => void; }) {
+export default function AdminEmpresas({
+  empresas,
+  credenciales,
+  onAgregar,
+  onEditar,
+}: {
+  empresas: string[];
+  credenciales: { usuario: string; password: string; empresa: string }[];
+  onAgregar: (nombre: string, usuario: string, password: string) => void;
+  onEditar: (empresa: string, usuario: string, password: string) => void;
+}) {
   const [nombre, setNombre] = useState("");
   const [usuario, setUsuario] = useState("");
   const [password, setPassword] = useState("");
+  const [editingIdx, setEditingIdx] = useState<number | null>(null);
+  const [editUsuario, setEditUsuario] = useState("");
+  const [editPassword, setEditPassword] = useState("");
 
   const handleAgregar = () => {
     if (!nombre.trim() || !usuario.trim() || !password.trim()) return;
@@ -13,15 +26,33 @@ export default function AdminEmpresas({ empresas, credenciales, onAgregar }:{ em
     setPassword("");
   };
 
+  const startEditar = (idx: number) => {
+    setEditingIdx(idx);
+    setEditUsuario(credenciales[idx].usuario);
+    setEditPassword(credenciales[idx].password);
+  };
+
+  const cancelarEditar = () => {
+    setEditingIdx(null);
+  };
+
+  const guardarEditar = (empresa: string) => {
+    if (editingIdx === null) return;
+    onEditar(empresa, editUsuario.trim(), editPassword.trim());
+    setEditingIdx(null);
+  };
+
   return (
     <div className="flex flex-col gap-4">
       <div className="overflow-x-auto">
-        <table className="w-full text-xs border mt-2 rounded-lg overflow-hidden font-montserrat text-[#172349]">
+        <table className="w-full text-xs sm:text-sm border mt-2 rounded-lg overflow-hidden font-montserrat text-[#172349]">
           <thead className="bg-gradient-to-r from-[#2EC4FF] to-[#005DFF] text-white font-semibold">
             <tr>
               <th>#</th>
               <th>Empresa</th>
               <th>Usuario</th>
+              <th>Contraseña</th>
+              <th></th>
             </tr>
           </thead>
           <tbody>
@@ -29,7 +60,50 @@ export default function AdminEmpresas({ empresas, credenciales, onAgregar }:{ em
               <tr key={idx} className="border-b">
                 <td className="px-2 py-1">{idx + 1}</td>
                 <td className="px-2 py-1">{c.empresa}</td>
-                <td className="px-2 py-1">{c.usuario}</td>
+                <td className="px-2 py-1">
+                  {editingIdx === idx ? (
+                    <input
+                      className="input w-24 sm:w-auto"
+                      value={editUsuario}
+                      onChange={(e) => setEditUsuario(e.target.value)}
+                    />
+                  ) : (
+                    c.usuario
+                  )}
+                </td>
+                <td className="px-2 py-1">
+                  {editingIdx === idx ? (
+                    <input
+                      className="input w-24 sm:w-auto"
+                      value={editPassword}
+                      onChange={(e) => setEditPassword(e.target.value)}
+                    />
+                  ) : (
+                    c.password
+                  )}
+                </td>
+                <td className="px-2 py-1 text-right">
+                  {editingIdx === idx ? (
+                    <>
+                      <button
+                        className="text-primary-main mr-2"
+                        onClick={() => guardarEditar(c.empresa)}
+                      >
+                        Guardar
+                      </button>
+                      <button className="text-red-600" onClick={cancelarEditar}>
+                        Cancelar
+                      </button>
+                    </>
+                  ) : (
+                    <button
+                      className="text-primary-main"
+                      onClick={() => startEditar(idx)}
+                    >
+                      Editar
+                    </button>
+                  )}
+                </td>
               </tr>
             ))}
           </tbody>

--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -32,6 +32,7 @@ type Props = {
   empresas?: string[];
   credenciales?: { usuario: string; password: string; empresa: string }[];
   onAgregarEmpresa?: (nombre: string, usuario: string, password: string) => void;
+  onEditarEmpresa?: (empresa: string, usuario: string, password: string) => void;
   onBack?: () => void;
 };
 
@@ -108,7 +109,15 @@ const categoriasFicha = [
 ] as const;
 
 
-export default function DashboardResultados({ soloGenerales, empresaFiltro, empresas: empresasConfig = [], credenciales = [], onAgregarEmpresa, onBack }: Props) {
+export default function DashboardResultados({
+  soloGenerales,
+  empresaFiltro,
+  empresas: empresasConfig = [],
+  credenciales = [],
+  onAgregarEmpresa,
+  onEditarEmpresa,
+  onBack,
+}: Props) {
   const [datos, setDatos] = useState<any[]>([]);
   const [empresaSeleccionada, setEmpresaSeleccionada] = useState(empresaFiltro || "todas");
   const [tab, setTab] = useState("general");
@@ -763,7 +772,12 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro, empr
         )}
         {!soloGenerales && (
           <TabsContent value="empresas">
-            <AdminEmpresas empresas={empresasConfig} credenciales={credenciales} onAgregar={onAgregarEmpresa || (()=>{})} />
+            <AdminEmpresas
+              empresas={empresasConfig}
+              credenciales={credenciales}
+              onAgregar={onAgregarEmpresa || (() => {})}
+              onEditar={onEditarEmpresa || (() => {})}
+            />
           </TabsContent>
         )}
       </Tabs>


### PR DESCRIPTION
## Summary
- include password when listing `credenciales`
- render password column and editing controls in AdminEmpresas
- pass through new `onEditarEmpresa` callback to dashboard
- keep credentials in localStorage up to date when edited

## Testing
- `npm run build` *(fails: Cannot find module 'react' or other dependencies)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6854584bf8cc8331bc675cb2de354bf9