### PR TITLE
Add CredencialEmpresa type

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import DashboardResultados from "./components/DashboardResultados";
 import Login from "./components/Login";
 import HomePage from "./components/HomePage";
 import credencialesBase from "./config/credentials.json";
+import { CredencialEmpresa } from "./types";
 import logoTexto from "./logo_texto.png";
 import {
   bloquesFormaA,
@@ -47,7 +48,7 @@ export default function App() {
     const guardadas = JSON.parse(localStorage.getItem("empresasCogent") || "[]");
     return guardadas.length ? guardadas : ["Sonria", "Aeropuerto El Dorado"];
   });
-  const [credenciales, setCredenciales] = useState<any[]>(() => {
+  const [credenciales, setCredenciales] = useState<(CredencialEmpresa & { rol: string })[]>(() => {
     const extras = JSON.parse(localStorage.getItem("credencialesCogent") || "[]");
     return [...credencialesBase, ...extras];
   });

--- a/src/components/AdminEmpresas.tsx
+++ b/src/components/AdminEmpresas.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
+import { CredencialEmpresa } from "@/types";
 
-export default function AdminEmpresas({ empresas, credenciales, onAgregar }:{ empresas: string[]; credenciales: { usuario: string; empresa: string }[]; onAgregar: (nombre: string, usuario: string, password: string) => void; }) {
+export default function AdminEmpresas({ empresas, credenciales, onAgregar }:{ empresas: string[]; credenciales: CredencialEmpresa[]; onAgregar: (nombre: string, usuario: string, password: string) => void; }) {
   const [nombre, setNombre] = useState("");
   const [usuario, setUsuario] = useState("");
   const [password, setPassword] = useState("");

--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -13,6 +13,7 @@ import TablaDimensiones from "@/components/TablaDimensiones";
 import GraficaBarra from "@/components/GraficaBarra";
 import GraficaBarraSimple from "@/components/GraficaBarraSimple";
 import AdminEmpresas from "@/components/AdminEmpresas";
+import { CredencialEmpresa } from "@/types";
 import GeneralResultsTabs from "@/components/dashboard/GeneralResultsTabs";
 import FormaTabs from "@/components/dashboard/FormaTabs";
 import LogoCogent from "/logo_forma.png";
@@ -30,7 +31,7 @@ type Props = {
   soloGenerales?: boolean;
   empresaFiltro?: string;
   empresas?: string[];
-  credenciales?: { usuario: string; password: string; empresa: string }[];
+  credenciales?: CredencialEmpresa[];
   onAgregarEmpresa?: (nombre: string, usuario: string, password: string) => void;
   onBack?: () => void;
 };

--- a/src/types/CredencialEmpresa.ts
+++ b/src/types/CredencialEmpresa.ts
@@ -1,0 +1,5 @@
+export interface CredencialEmpresa {
+  usuario: string;
+  password: string;
+  empresa: string;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,1 @@
+export * from './CredencialEmpresa';


### PR DESCRIPTION
## Summary
- add `CredencialEmpresa` interface in `src/types`
- use the new type in `AdminEmpresas` and `DashboardResultados`
- update `App` state to leverage the shared interface

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: cannot find module 'react' or corresponding types)*

------
https://chatgpt.com/codex/tasks/task_e_6854589ecf2083318db75afcbc2ecba1