### PR TITLE
Add credential editing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -80,6 +80,18 @@ export default function App() {
     setCredenciales([...credencialesBase, ...extras]);
   };
 
+  const editarCredencial = (
+    index: number,
+    usuario: string,
+    password: string
+  ) => {
+    const extras = JSON.parse(localStorage.getItem("credencialesCogent") || "[]");
+    if (index < 0 || index >= extras.length) return;
+    extras[index] = { ...extras[index], usuario, password };
+    localStorage.setItem("credencialesCogent", JSON.stringify(extras));
+    setCredenciales([...credencialesBase, ...extras]);
+  };
+
   // Cuando finaliza la encuesta (luego del bloque de estrés)
   useEffect(() => {
     if (step === "final") {
@@ -165,6 +177,7 @@ export default function App() {
         empresas={empresasIniciales}
         credenciales={credenciales.filter((c) => c.rol === "dueno")}
         onAgregarEmpresa={agregarEmpresa}
+        onEditarCredencial={editarCredencial}
         onBack={() => setStep("inicio")}
       />
     );

--- a/src/components/AdminEmpresas.tsx
+++ b/src/components/AdminEmpresas.tsx
@@ -1,9 +1,22 @@
 import React, { useState } from "react";
 
-export default function AdminEmpresas({ empresas, credenciales, onAgregar }:{ empresas: string[]; credenciales: { usuario: string; empresa: string }[]; onAgregar: (nombre: string, usuario: string, password: string) => void; }) {
+export default function AdminEmpresas({
+  empresas,
+  credenciales,
+  onAgregar,
+  onEditar,
+}:{
+  empresas: string[];
+  credenciales: { usuario: string; empresa: string }[];
+  onAgregar: (nombre: string, usuario: string, password: string) => void;
+  onEditar: (index: number, usuario: string, password: string) => void;
+}) {
   const [nombre, setNombre] = useState("");
   const [usuario, setUsuario] = useState("");
   const [password, setPassword] = useState("");
+  const [editIndex, setEditIndex] = useState<number | null>(null);
+  const [editUsuario, setEditUsuario] = useState("");
+  const [editPassword, setEditPassword] = useState("");
 
   const handleAgregar = () => {
     if (!nombre.trim() || !usuario.trim() || !password.trim()) return;
@@ -11,6 +24,21 @@ export default function AdminEmpresas({ empresas, credenciales, onAgregar }:{ em
     setNombre("");
     setUsuario("");
     setPassword("");
+  };
+
+  const startEdit = (idx: number) => {
+    setEditIndex(idx);
+    setEditUsuario(credenciales[idx].usuario);
+    setEditPassword("");
+  };
+
+  const handleGuardarEdicion = () => {
+    if (editIndex === null) return;
+    if (!editUsuario.trim() || !editPassword.trim()) return;
+    onEditar(editIndex, editUsuario.trim(), editPassword.trim());
+    setEditIndex(null);
+    setEditUsuario("");
+    setEditPassword("");
   };
 
   return (
@@ -22,6 +50,7 @@ export default function AdminEmpresas({ empresas, credenciales, onAgregar }:{ em
               <th>#</th>
               <th>Empresa</th>
               <th>Usuario</th>
+              <th></th>
             </tr>
           </thead>
           <tbody>
@@ -30,19 +59,81 @@ export default function AdminEmpresas({ empresas, credenciales, onAgregar }:{ em
                 <td className="px-2 py-1">{idx + 1}</td>
                 <td className="px-2 py-1">{c.empresa}</td>
                 <td className="px-2 py-1">{c.usuario}</td>
+                <td className="px-2 py-1 text-right">
+                  <button
+                    type="button"
+                    className="text-primary-main underline"
+                    onClick={() => startEdit(idx)}
+                  >
+                    Editar
+                  </button>
+                </td>
               </tr>
             ))}
           </tbody>
         </table>
       </div>
-      <div className="flex flex-wrap gap-2 items-center">
-        <input className="input flex-1" placeholder="Nombre empresa" value={nombre} onChange={(e)=>setNombre(e.target.value)} />
-        <input className="input flex-1" placeholder="Usuario" value={usuario} onChange={(e)=>setUsuario(e.target.value)} />
-        <input className="input flex-1" type="password" placeholder="Contraseña" value={password} onChange={(e)=>setPassword(e.target.value)} />
-        <button type="button" className="bg-primary-main text-white px-4 py-1 rounded-lg shadow" onClick={handleAgregar}>
-          Agregar
-        </button>
-      </div>
+      {editIndex === null ? (
+        <div className="flex flex-wrap gap-2 items-center">
+          <input
+            className="input flex-1"
+            placeholder="Nombre empresa"
+            value={nombre}
+            onChange={(e) => setNombre(e.target.value)}
+          />
+          <input
+            className="input flex-1"
+            placeholder="Usuario"
+            value={usuario}
+            onChange={(e) => setUsuario(e.target.value)}
+          />
+          <input
+            className="input flex-1"
+            type="password"
+            placeholder="Contraseña"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          <button
+            type="button"
+            className="bg-primary-main text-white px-4 py-1 rounded-lg shadow"
+            onClick={handleAgregar}
+          >
+            Agregar
+          </button>
+        </div>
+      ) : (
+        <div className="flex flex-wrap gap-2 items-center">
+          <span className="font-semibold">{credenciales[editIndex].empresa}</span>
+          <input
+            className="input flex-1"
+            placeholder="Usuario"
+            value={editUsuario}
+            onChange={(e) => setEditUsuario(e.target.value)}
+          />
+          <input
+            className="input flex-1"
+            type="password"
+            placeholder="Contraseña"
+            value={editPassword}
+            onChange={(e) => setEditPassword(e.target.value)}
+          />
+          <button
+            type="button"
+            className="bg-primary-main text-white px-4 py-1 rounded-lg shadow"
+            onClick={handleGuardarEdicion}
+          >
+            Guardar
+          </button>
+          <button
+            type="button"
+            className="px-4 py-1 rounded-lg border"
+            onClick={() => setEditIndex(null)}
+          >
+            Cancelar
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -32,6 +32,7 @@ type Props = {
   empresas?: string[];
   credenciales?: { usuario: string; password: string; empresa: string }[];
   onAgregarEmpresa?: (nombre: string, usuario: string, password: string) => void;
+  onEditarCredencial?: (index: number, usuario: string, password: string) => void;
   onBack?: () => void;
 };
 
@@ -108,7 +109,7 @@ const categoriasFicha = [
 ] as const;
 
 
-export default function DashboardResultados({ soloGenerales, empresaFiltro, empresas: empresasConfig = [], credenciales = [], onAgregarEmpresa, onBack }: Props) {
+export default function DashboardResultados({ soloGenerales, empresaFiltro, empresas: empresasConfig = [], credenciales = [], onAgregarEmpresa, onEditarCredencial, onBack }: Props) {
   const [datos, setDatos] = useState<any[]>([]);
   const [empresaSeleccionada, setEmpresaSeleccionada] = useState(empresaFiltro || "todas");
   const [tab, setTab] = useState("general");
@@ -763,7 +764,12 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro, empr
         )}
         {!soloGenerales && (
           <TabsContent value="empresas">
-            <AdminEmpresas empresas={empresasConfig} credenciales={credenciales} onAgregar={onAgregarEmpresa || (()=>{})} />
+            <AdminEmpresas
+              empresas={empresasConfig}
+              credenciales={credenciales}
+              onAgregar={onAgregarEmpresa || (() => {})}
+              onEditar={onEditarCredencial || (() => {})}
+            />
           </TabsContent>
         )}
       </Tabs>


### PR DESCRIPTION
## Summary
- add `editarCredencial` to update saved credentials in `App`
- expose edit handler through `DashboardResultados`
- implement editing UI in `AdminEmpresas`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685458b05e2c833182e99ed99e13d177