### PR TITLE
Add credential deletion from dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,7 @@ You can adjust or add accounts by editing this file:
 - **Sonria**: `sonria` / `sonria123`
 - **Aeropuerto**: `aeropuerto` / `eldorado123`
 
+From the dashboard, each credential now shows **Editar** and **Eliminar** buttons.
+Use **Eliminar** to remove a custom credential; this deletes it from `localStorage`
+and from the table instantly.
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -80,6 +80,13 @@ export default function App() {
     setCredenciales([...credencialesBase, ...extras]);
   };
 
+  const eliminarEmpresa = (usuario: string) => {
+    const extras = JSON.parse(localStorage.getItem("credencialesCogent") || "[]");
+    const filtradas = extras.filter((c: any) => c.usuario !== usuario);
+    localStorage.setItem("credencialesCogent", JSON.stringify(filtradas));
+    setCredenciales([...credencialesBase, ...filtradas]);
+  };
+
   // Cuando finaliza la encuesta (luego del bloque de estrés)
   useEffect(() => {
     if (step === "final") {
@@ -165,6 +172,7 @@ export default function App() {
         empresas={empresasIniciales}
         credenciales={credenciales.filter((c) => c.rol === "dueno")}
         onAgregarEmpresa={agregarEmpresa}
+        onEliminarEmpresa={eliminarEmpresa}
         onBack={() => setStep("inicio")}
       />
     );

--- a/src/components/AdminEmpresas.tsx
+++ b/src/components/AdminEmpresas.tsx
@@ -1,6 +1,16 @@
 import React, { useState } from "react";
 
-export default function AdminEmpresas({ empresas, credenciales, onAgregar }:{ empresas: string[]; credenciales: { usuario: string; empresa: string }[]; onAgregar: (nombre: string, usuario: string, password: string) => void; }) {
+export default function AdminEmpresas({
+  empresas,
+  credenciales,
+  onAgregar,
+  onEliminar
+}: {
+  empresas: string[];
+  credenciales: { usuario: string; empresa: string }[];
+  onAgregar: (nombre: string, usuario: string, password: string) => void;
+  onEliminar: (usuario: string) => void;
+}) {
   const [nombre, setNombre] = useState("");
   const [usuario, setUsuario] = useState("");
   const [password, setPassword] = useState("");
@@ -22,6 +32,7 @@ export default function AdminEmpresas({ empresas, credenciales, onAgregar }:{ em
               <th>#</th>
               <th>Empresa</th>
               <th>Usuario</th>
+              <th className="w-28">Acciones</th>
             </tr>
           </thead>
           <tbody>
@@ -30,6 +41,23 @@ export default function AdminEmpresas({ empresas, credenciales, onAgregar }:{ em
                 <td className="px-2 py-1">{idx + 1}</td>
                 <td className="px-2 py-1">{c.empresa}</td>
                 <td className="px-2 py-1">{c.usuario}</td>
+                <td className="px-2 py-1">
+                  <div className="flex gap-1">
+                    <button
+                      type="button"
+                      className="px-2 py-0.5 text-xs bg-yellow-400 rounded"
+                    >
+                      Editar
+                    </button>
+                    <button
+                      type="button"
+                      className="px-2 py-0.5 text-xs bg-red-600 text-white rounded"
+                      onClick={() => onEliminar(c.usuario)}
+                    >
+                      Eliminar
+                    </button>
+                  </div>
+                </td>
               </tr>
             ))}
           </tbody>

--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -32,6 +32,7 @@ type Props = {
   empresas?: string[];
   credenciales?: { usuario: string; password: string; empresa: string }[];
   onAgregarEmpresa?: (nombre: string, usuario: string, password: string) => void;
+  onEliminarEmpresa?: (usuario: string) => void;
   onBack?: () => void;
 };
 
@@ -108,7 +109,15 @@ const categoriasFicha = [
 ] as const;
 
 
-export default function DashboardResultados({ soloGenerales, empresaFiltro, empresas: empresasConfig = [], credenciales = [], onAgregarEmpresa, onBack }: Props) {
+export default function DashboardResultados({
+  soloGenerales,
+  empresaFiltro,
+  empresas: empresasConfig = [],
+  credenciales = [],
+  onAgregarEmpresa,
+  onEliminarEmpresa,
+  onBack
+}: Props) {
   const [datos, setDatos] = useState<any[]>([]);
   const [empresaSeleccionada, setEmpresaSeleccionada] = useState(empresaFiltro || "todas");
   const [tab, setTab] = useState("general");
@@ -763,7 +772,12 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro, empr
         )}
         {!soloGenerales && (
           <TabsContent value="empresas">
-            <AdminEmpresas empresas={empresasConfig} credenciales={credenciales} onAgregar={onAgregarEmpresa || (()=>{})} />
+            <AdminEmpresas
+              empresas={empresasConfig}
+              credenciales={credenciales}
+              onAgregar={onAgregarEmpresa || (() => {})}
+              onEliminar={onEliminarEmpresa || (() => {})}
+            />
           </TabsContent>
         )}
       </Tabs>


### PR DESCRIPTION
## Summary
- show Editar/Eliminar buttons in the AdminEmpresas table
- support `onEliminar` callback to remove stored credentials
- wire deletion callback from DashboardResultados up to `App`
- mention credential management in README

## Testing
- `npx tsc -p tsconfig.app.json` *(fails: Cannot find package)*
- `npm run lint` *(fails: Cannot find package)*

------
https://chatgpt.com/codex/tasks/task_e_685459404eec8331967f1914ba3ad3f1