### PR TITLE
Add credential deletion from dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,9 @@ You can adjust or add accounts by editing this file:
 - **Sonria**: `sonria` / `sonria123`
 - **Aeropuerto**: `aeropuerto` / `eldorado123`
 
+In the dashboard's **Empresas** tab you can review all stored credentials,
+including their passwords. Each entry provides **Editar** and **Eliminar**
+actions. **Eliminar** removes a custom credential from `localStorage` and the
+table instantly, while **Editar** lets you update the company name, username or
+password.
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -80,6 +80,37 @@ export default function App() {
     setCredenciales([...credencialesBase, ...extras]);
   };
 
+  const eliminarEmpresa = (usuario: string) => {
+    const extras = JSON.parse(localStorage.getItem("credencialesCogent") || "[]");
+    const filtradas = extras.filter((c: any) => c.usuario !== usuario);
+    localStorage.setItem("credencialesCogent", JSON.stringify(filtradas));
+    setCredenciales([...credencialesBase, ...filtradas]);
+  };
+
+  const editarEmpresa = (
+    originalUsuario: string,
+    nombre: string,
+    usuario: string,
+    password: string
+  ) => {
+    const extras = JSON.parse(localStorage.getItem("credencialesCogent") || "[]");
+    const nuevas = extras.map((c: any) =>
+      c.usuario === originalUsuario
+        ? { usuario, password, rol: "dueno", empresa: nombre }
+        : c
+    );
+    localStorage.setItem("credencialesCogent", JSON.stringify(nuevas));
+    setCredenciales([...credencialesBase, ...nuevas]);
+    const empresasGuardadas = JSON.parse(localStorage.getItem("empresasCogent") || "[]");
+    const anterior = extras.find((c: any) => c.usuario === originalUsuario)?.empresa;
+    let nuevasEmp = empresasGuardadas.filter((e: string) => e !== anterior);
+    if (!nuevasEmp.includes(nombre)) {
+      nuevasEmp.push(nombre);
+    }
+    setEmpresasIniciales(nuevasEmp);
+    localStorage.setItem("empresasCogent", JSON.stringify(nuevasEmp));
+  };
+
   // Cuando finaliza la encuesta (luego del bloque de estrés)
   useEffect(() => {
     if (step === "final") {
@@ -165,6 +196,8 @@ export default function App() {
         empresas={empresasIniciales}
         credenciales={credenciales.filter((c) => c.rol === "dueno")}
         onAgregarEmpresa={agregarEmpresa}
+        onEliminarEmpresa={eliminarEmpresa}
+        onEditarEmpresa={editarEmpresa}
         onBack={() => setStep("inicio")}
       />
     );

--- a/src/components/AdminEmpresas.tsx
+++ b/src/components/AdminEmpresas.tsx
@@ -1,9 +1,30 @@
 import React, { useState } from "react";
 
-export default function AdminEmpresas({ empresas, credenciales, onAgregar }:{ empresas: string[]; credenciales: { usuario: string; empresa: string }[]; onAgregar: (nombre: string, usuario: string, password: string) => void; }) {
+export default function AdminEmpresas({
+  empresas,
+  credenciales,
+  onAgregar,
+  onEliminar,
+  onEditar
+}: {
+  empresas: string[];
+  credenciales: { usuario: string; password: string; empresa: string }[];
+  onAgregar: (nombre: string, usuario: string, password: string) => void;
+  onEliminar: (usuario: string) => void;
+  onEditar: (
+    originalUsuario: string,
+    nombre: string,
+    usuario: string,
+    password: string
+  ) => void;
+}) {
   const [nombre, setNombre] = useState("");
   const [usuario, setUsuario] = useState("");
   const [password, setPassword] = useState("");
+  const [editIdx, setEditIdx] = useState<number | null>(null);
+  const [editNombre, setEditNombre] = useState("");
+  const [editUsuario, setEditUsuario] = useState("");
+  const [editPassword, setEditPassword] = useState("");
 
   const handleAgregar = () => {
     if (!nombre.trim() || !usuario.trim() || !password.trim()) return;
@@ -22,14 +43,93 @@ export default function AdminEmpresas({ empresas, credenciales, onAgregar }:{ em
               <th>#</th>
               <th>Empresa</th>
               <th>Usuario</th>
+              <th>Contraseña</th>
+              <th className="w-32">Acciones</th>
             </tr>
           </thead>
           <tbody>
             {credenciales.map((c, idx) => (
               <tr key={idx} className="border-b">
                 <td className="px-2 py-1">{idx + 1}</td>
-                <td className="px-2 py-1">{c.empresa}</td>
-                <td className="px-2 py-1">{c.usuario}</td>
+                <td className="px-2 py-1">
+                  {editIdx === idx ? (
+                    <input
+                      className="input"
+                      value={editNombre}
+                      onChange={(e) => setEditNombre(e.target.value)}
+                    />
+                  ) : (
+                    c.empresa
+                  )}
+                </td>
+                <td className="px-2 py-1">
+                  {editIdx === idx ? (
+                    <input
+                      className="input"
+                      value={editUsuario}
+                      onChange={(e) => setEditUsuario(e.target.value)}
+                    />
+                  ) : (
+                    c.usuario
+                  )}
+                </td>
+                <td className="px-2 py-1">
+                  {editIdx === idx ? (
+                    <input
+                      className="input"
+                      type="text"
+                      value={editPassword}
+                      onChange={(e) => setEditPassword(e.target.value)}
+                    />
+                  ) : (
+                    c.password
+                  )}
+                </td>
+                <td className="px-2 py-1">
+                  {editIdx === idx ? (
+                    <div className="flex gap-1">
+                      <button
+                        type="button"
+                        className="px-2 py-0.5 text-xs bg-green-500 text-white rounded"
+                        onClick={() => {
+                          onEditar(c.usuario, editNombre, editUsuario, editPassword);
+                          setEditIdx(null);
+                        }}
+                      >
+                        Guardar
+                      </button>
+                      <button
+                        type="button"
+                        className="px-2 py-0.5 text-xs bg-gray-300 rounded"
+                        onClick={() => setEditIdx(null)}
+                      >
+                        Cancelar
+                      </button>
+                    </div>
+                  ) : (
+                    <div className="flex gap-1">
+                      <button
+                        type="button"
+                        className="px-2 py-0.5 text-xs bg-yellow-400 rounded"
+                        onClick={() => {
+                          setEditIdx(idx);
+                          setEditNombre(c.empresa);
+                          setEditUsuario(c.usuario);
+                          setEditPassword(c.password);
+                        }}
+                      >
+                        Editar
+                      </button>
+                      <button
+                        type="button"
+                        className="px-2 py-0.5 text-xs bg-red-600 text-white rounded"
+                        onClick={() => onEliminar(c.usuario)}
+                      >
+                        Eliminar
+                      </button>
+                    </div>
+                  )}
+                </td>
               </tr>
             ))}
           </tbody>

--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -32,6 +32,13 @@ type Props = {
   empresas?: string[];
   credenciales?: { usuario: string; password: string; empresa: string }[];
   onAgregarEmpresa?: (nombre: string, usuario: string, password: string) => void;
+  onEliminarEmpresa?: (usuario: string) => void;
+  onEditarEmpresa?: (
+    originalUsuario: string,
+    nombre: string,
+    usuario: string,
+    password: string
+  ) => void;
   onBack?: () => void;
 };
 
@@ -108,7 +115,16 @@ const categoriasFicha = [
 ] as const;
 
 
-export default function DashboardResultados({ soloGenerales, empresaFiltro, empresas: empresasConfig = [], credenciales = [], onAgregarEmpresa, onBack }: Props) {
+export default function DashboardResultados({
+  soloGenerales,
+  empresaFiltro,
+  empresas: empresasConfig = [],
+  credenciales = [],
+  onAgregarEmpresa,
+  onEliminarEmpresa,
+  onEditarEmpresa,
+  onBack
+}: Props) {
   const [datos, setDatos] = useState<any[]>([]);
   const [empresaSeleccionada, setEmpresaSeleccionada] = useState(empresaFiltro || "todas");
   const [tab, setTab] = useState("general");
@@ -763,7 +779,13 @@ export default function DashboardResultados({ soloGenerales, empresaFiltro, empr
         )}
         {!soloGenerales && (
           <TabsContent value="empresas">
-            <AdminEmpresas empresas={empresasConfig} credenciales={credenciales} onAgregar={onAgregarEmpresa || (()=>{})} />
+            <AdminEmpresas
+              empresas={empresasConfig}
+              credenciales={credenciales}
+              onAgregar={onAgregarEmpresa || (() => {})}
+              onEliminar={onEliminarEmpresa || (() => {})}
+              onEditar={onEditarEmpresa || (() => {})}
+            />
           </TabsContent>
         )}
       </Tabs>


### PR DESCRIPTION
## Summary
- show Editar/Eliminar buttons in the AdminEmpresas table
- display stored passwords and support inline editing
- wire `onEditarEmpresa` callback from DashboardResultados up to `App`
- mention credential management in README

## Testing
- `npx tsc -p tsconfig.app.json` *(fails: Cannot find module)*
- `npm run lint` *(fails: Cannot find package)*

------
https://chatgpt.com/codex/tasks/task_e_685459404eec8331967f1914ba3ad3f1