### PR TITLE
Add greeting to dashboard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -65,6 +65,7 @@ export default function App() {
 
   // Manejo de login (muy básico)
   const [rol, setRol] = useState<RolUsuario>("ninguno");
+  const [empresaActual, setEmpresaActual] = useState<string | null>(null);
 
   const agregarEmpresa = (
     nombre: string,
@@ -180,8 +181,9 @@ export default function App() {
     return (
       <Login
         usuarios={credenciales}
-        onLogin={(nuevoRol) => {
+        onLogin={(nuevoRol, empresa) => {
           setRol(nuevoRol as RolUsuario);
+          setEmpresaActual(empresa || null);
           setStep("dashboard");
         }}
         onCancel={() => setStep("inicio")}
@@ -193,6 +195,8 @@ export default function App() {
   if (step === "dashboard") {
     return (
       <DashboardResultados
+        rol={rol as "psicologa" | "dueno"}
+        empresaNombre={empresaActual || undefined}
         soloGenerales={rol === "dueno"}
         empresas={empresasIniciales}
         credenciales={credenciales.filter((c) => c.rol === "dueno")}

--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -28,6 +28,8 @@ const nivelesRiesgo = [
 ];
 
 type Props = {
+  rol: "psicologa" | "dueno";
+  empresaNombre?: string;
   soloGenerales?: boolean;
   empresaFiltro?: string;
   empresas?: string[];
@@ -117,6 +119,8 @@ const categoriasFicha = [
 
 
 export default function DashboardResultados({
+  rol,
+  empresaNombre,
   soloGenerales,
   empresaFiltro,
   empresas: empresasConfig = [],
@@ -141,6 +145,9 @@ export default function DashboardResultados({
   const [chartType, setChartType] = useState<"bar" | "histogram" | "pie">("bar");
   const [seleccionados, setSeleccionados] = useState<number[]>([]);
   const containerRef = useRef<HTMLDivElement>(null);
+
+  const saludo = rol === "psicologa" ? "Hola Lilian Navas" : empresaNombre || "";
+  const cargo = rol === "psicologa" ? "Psicologist" : "Empresa";
 
   const tabPill =
     "px-5 py-2 rounded-full font-semibold border border-[#B2E2FF] text-[#172349] shrink-0 data-[state=active]:text-white data-[state=active]:bg-gradient-to-r data-[state=active]:from-[#38BDF8] data-[state=active]:to-[#265FF2]";
@@ -489,9 +496,15 @@ export default function DashboardResultados({
         ref={containerRef}
         className="w-full max-w-7xl bg-white rounded-2xl shadow-xl p-8 md:p-10 flex flex-col gap-8"
       >
-        <div className="flex items-center mb-4">
-          <img src={LogoCogent} alt="COGENT logo" className="w-10 h-10 mr-3" />
-          <h2 className="text-2xl md:text-3xl font-bold text-[#172349] font-montserrat">Dashboard de Resultados</h2>
+        <div className="flex items-center justify-between mb-4">
+          <div className="flex items-center">
+            <img src={LogoCogent} alt="COGENT logo" className="w-10 h-10 mr-3" />
+            <h2 className="text-2xl md:text-3xl font-bold text-[#172349] font-montserrat">Dashboard de Resultados</h2>
+          </div>
+          <div className="text-right">
+            <div className="font-bold text-[#172349] font-montserrat">{saludo}</div>
+            <div className="text-sm text-[#6C7A89] font-montserrat">{cargo}</div>
+          </div>
         </div>
         <div className="h-px bg-[#E5EAF6]" />
 


### PR DESCRIPTION
## Summary
- store selected company name on login
- display greeting in dashboard header for psychologist or company

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68546b93c848833198fc6d32e78eb611