### PR TITLE
Add averages row to individual result tables

### DIFF
--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -387,6 +387,51 @@ export default function DashboardResultados({
     [datosInforme]
   );
 
+  const promedioInforme = useMemo(() => {
+    const nivelesMap: Record<string, number> = {};
+    nivelesRiesgo.forEach((n, i) => {
+      nivelesMap[n] = i;
+    });
+    nivelesMap["Sin riesgo"] = 0;
+
+    const nivelesEstresMap: Record<string, number> = {};
+    nivelesEstres.forEach((n, i) => {
+      nivelesEstresMap[n] = i;
+    });
+
+    const row: Record<string, any> = {};
+    allHeaders.forEach((h) => {
+      const valores = datosInforme
+        .map((f) => f[h])
+        .filter((v) => v !== undefined && v !== "");
+      const nums = valores
+        .map((v) => Number(v))
+        .filter((v) => !isNaN(v));
+      if (nums.length) {
+        const avg = nums.reduce((a, b) => a + b, 0) / nums.length;
+        row[h] = Math.round(avg * 10) / 10;
+        return;
+      }
+      const mapa = h.toLowerCase().includes("estrés")
+        ? nivelesEstresMap
+        : nivelesMap;
+      const niveles = valores
+        .map((v) => mapa[v as string])
+        .filter((v) => typeof v === "number");
+      if (niveles.length) {
+        const idx = Math.round(niveles.reduce((a, b) => a + b, 0) / niveles.length);
+        const lista = h.toLowerCase().includes("estrés") ? nivelesEstres : nivelesRiesgo;
+        row[h] = lista[idx] || "";
+      } else {
+        row[h] = "";
+      }
+    });
+    if (allHeaders.length) {
+      row[allHeaders[0]] = "Promedio";
+    }
+    return row;
+  }, [datosInforme, allHeaders]);
+
 
   // ---- Exportar a Excel ----
   const handleExportar = () => {
@@ -740,6 +785,13 @@ export default function DashboardResultados({
                       ))}
                     </tr>
                   ))}
+                  <tr className="font-semibold bg-gray-100">
+                    {allHeaders.map((h, idx) => (
+                      <td key={idx} className="px-2 py-1">
+                        {promedioInforme[h] ?? ""}
+                      </td>
+                    ))}
+                  </tr>
                 </tbody>
               </table>
             </div>

--- a/src/components/TablaIndividual.tsx
+++ b/src/components/TablaIndividual.tsx
@@ -1,6 +1,69 @@
-import React from "react";
+import React, { useMemo } from "react";
 
 export default function TablaIndividual({ datos, tipo }: { datos: any[]; tipo: string }) {
+  const promedios = useMemo(() => {
+    const nivelesRiesgo = [
+      "Riesgo muy bajo",
+      "Riesgo bajo",
+      "Riesgo medio",
+      "Riesgo alto",
+      "Riesgo muy alto",
+    ];
+    const nivelesEstres = ["Muy bajo", "Bajo", "Medio", "Alto", "Muy alto"];
+    const usarEstres = tipo === "estres";
+    const listaNiveles = usarEstres ? nivelesEstres : nivelesRiesgo;
+    let suma = 0;
+    let cuenta = 0;
+    const indices: number[] = [];
+    datos.forEach((d) => {
+      let puntaje: number | undefined;
+      let nivel: string | undefined;
+      if (tipo === "formaA") {
+        puntaje = d.resultadoFormaA?.total?.transformado;
+        nivel = d.resultadoFormaA?.total?.nivel;
+      } else if (tipo === "formaB") {
+        puntaje =
+          d.resultadoFormaB?.total?.transformado ??
+          d.resultadoFormaB?.puntajeTransformadoTotal ??
+          d.resultadoFormaB?.puntajeTransformado ??
+          d.resultadoFormaB?.puntajeTotalTransformado;
+        nivel =
+          d.resultadoFormaB?.total?.nivel ??
+          d.resultadoFormaB?.nivelTotal ??
+          d.resultadoFormaB?.nivel;
+      } else if (tipo === "extralaboral") {
+        puntaje = d.resultadoExtralaboral?.puntajeTransformadoTotal;
+        nivel = d.resultadoExtralaboral?.nivelGlobal;
+      } else if (tipo === "globalExtra") {
+        puntaje =
+          d.resultadoGlobalAExtralaboral?.puntajeGlobal ??
+          d.resultadoGlobalBExtralaboral?.puntajeGlobal;
+        nivel =
+          d.resultadoGlobalAExtralaboral?.nivelGlobal ??
+          d.resultadoGlobalBExtralaboral?.nivelGlobal;
+      } else if (tipo === "estres") {
+        puntaje = d.resultadoEstres?.puntajeTransformado;
+        nivel = d.resultadoEstres?.nivel;
+      }
+      if (typeof puntaje === "number") {
+        suma += puntaje;
+        cuenta += 1;
+      }
+      if (nivel) {
+        const n = nivel === "Sin riesgo" ? "Riesgo muy bajo" : nivel;
+        const idx = listaNiveles.indexOf(n);
+        if (idx >= 0) indices.push(idx);
+      }
+    });
+    const promPuntaje = cuenta ? Math.round((suma / cuenta) * 10) / 10 : "";
+    const promNivel =
+      indices.length > 0
+        ? listaNiveles[
+            Math.round(indices.reduce((a, b) => a + b, 0) / indices.length)
+          ]
+        : "";
+    return { puntaje: promPuntaje, nivel: promNivel };
+  }, [datos, tipo]);
   if (datos.length === 0) {
     return <div className="py-6 text-gray-400">No hay resultados individuales para mostrar.</div>;
   }
@@ -105,6 +168,44 @@ export default function TablaIndividual({ datos, tipo }: { datos: any[]; tipo: s
               <td>{d.fecha ? new Date(d.fecha).toLocaleString() : ""}</td>
             </tr>
           ))}
+          <tr className="font-semibold bg-gray-100">
+            <td></td>
+            <td>Promedio</td>
+            <td></td>
+            <td></td>
+            <td></td>
+            {tipo === "formaA" && (
+              <>
+                <td>{promedios.puntaje}</td>
+                <td>{promedios.nivel}</td>
+              </>
+            )}
+            {tipo === "formaB" && (
+              <>
+                <td>{promedios.puntaje}</td>
+                <td>{promedios.nivel}</td>
+              </>
+            )}
+            {tipo === "extralaboral" && (
+              <>
+                <td>{promedios.puntaje}</td>
+                <td>{promedios.nivel}</td>
+              </>
+            )}
+            {tipo === "globalExtra" && (
+              <>
+                <td>{promedios.puntaje}</td>
+                <td>{promedios.nivel}</td>
+              </>
+            )}
+            {tipo === "estres" && (
+              <>
+                <td>{promedios.puntaje}</td>
+                <td>{promedios.nivel}</td>
+              </>
+            )}
+            <td></td>
+          </tr>
         </tbody>
       </table>
     </div>


### PR DESCRIPTION
## Summary
- compute average puntaje and level in `TablaIndividual`
- show a final "Promedio" row in every individual results table

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68546d6f878883319f13ef74e900cd0c