### PR TITLE
Add averages row to domain/dimension tables

### DIFF
--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -387,6 +387,51 @@ export default function DashboardResultados({
     [datosInforme]
   );
 
+  const promedioInforme = useMemo(() => {
+    const nivelesMap: Record<string, number> = {};
+    nivelesRiesgo.forEach((n, i) => {
+      nivelesMap[n] = i;
+    });
+    nivelesMap["Sin riesgo"] = 0;
+
+    const nivelesEstresMap: Record<string, number> = {};
+    nivelesEstres.forEach((n, i) => {
+      nivelesEstresMap[n] = i;
+    });
+
+    const row: Record<string, any> = {};
+    allHeaders.forEach((h) => {
+      const valores = datosInforme
+        .map((f) => f[h])
+        .filter((v) => v !== undefined && v !== "");
+      const nums = valores
+        .map((v) => Number(v))
+        .filter((v) => !isNaN(v));
+      if (nums.length) {
+        const avg = nums.reduce((a, b) => a + b, 0) / nums.length;
+        row[h] = Math.round(avg * 10) / 10;
+        return;
+      }
+      const mapa = h.toLowerCase().includes("estrés")
+        ? nivelesEstresMap
+        : nivelesMap;
+      const niveles = valores
+        .map((v) => mapa[v as string])
+        .filter((v) => typeof v === "number");
+      if (niveles.length) {
+        const idx = Math.round(niveles.reduce((a, b) => a + b, 0) / niveles.length);
+        const lista = h.toLowerCase().includes("estrés") ? nivelesEstres : nivelesRiesgo;
+        row[h] = lista[idx] || "";
+      } else {
+        row[h] = "";
+      }
+    });
+    if (allHeaders.length) {
+      row[allHeaders[0]] = "Promedio";
+    }
+    return row;
+  }, [datosInforme, allHeaders]);
+
 
   // ---- Exportar a Excel ----
   const handleExportar = () => {
@@ -740,6 +785,13 @@ export default function DashboardResultados({
                       ))}
                     </tr>
                   ))}
+                  <tr className="font-semibold bg-gray-100">
+                    {allHeaders.map((h, idx) => (
+                      <td key={idx} className="px-2 py-1">
+                        {promedioInforme[h] ?? ""}
+                      </td>
+                    ))}
+                  </tr>
                 </tbody>
               </table>
             </div>

--- a/src/components/TablaDimensiones.tsx
+++ b/src/components/TablaDimensiones.tsx
@@ -1,6 +1,45 @@
-import React from "react";
+import React, { useMemo } from "react";
+import { baremosFormaA } from "@/data/baremosFormaA";
+import { baremosFormaB } from "@/data/baremosFormaB";
 
 export default function TablaDimensiones({ datos, dimensiones, keyResultado }: { datos: any[]; dimensiones: string[]; keyResultado: string }) {
+  const nivelesRiesgo = [
+    "Riesgo muy bajo",
+    "Riesgo bajo",
+    "Riesgo medio",
+    "Riesgo alto",
+    "Riesgo muy alto",
+  ];
+
+  const promedios = useMemo(() => {
+    const origen = keyResultado.toLowerCase().includes("formab") ? "formaB" : "formaA";
+    return dimensiones.map((dim) => {
+      const valores = datos
+        .map((d) => {
+          let seccion = d[keyResultado]?.dimensiones?.[dim];
+          if (Array.isArray(d[keyResultado]?.dimensiones)) {
+            seccion = d[keyResultado].dimensiones.find((x: any) => x.nombre === dim);
+          }
+          if (typeof seccion === "object") {
+            return seccion.transformado ?? seccion.puntajeTransformado;
+          }
+          return d[keyResultado]?.puntajesDimension?.[dim];
+        })
+        .filter((v: any) => typeof v === "number");
+      const prom = valores.length ? valores.reduce((a, b) => a + b, 0) / valores.length : 0;
+      const promedio = Math.round(prom * 10) / 10;
+      const baremos =
+        origen === "formaA"
+          ? (baremosFormaA.dimensiones as any)[dim] || []
+          : (baremosFormaB.dimension as any)[dim] || [];
+      const nivel =
+        baremos.find((b: any) => promedio >= b.min && promedio <= b.max)?.nivel || "No clasificado";
+      return {
+        promedio,
+        nivel: nivel === "Sin riesgo" ? "Riesgo muy bajo" : nivel,
+      };
+    });
+  }, [datos, dimensiones, keyResultado]);
   if (datos.length === 0) {
     return <div className="py-6 text-gray-400">No hay resultados de dimensiones para mostrar.</div>;
   }
@@ -37,6 +76,22 @@ export default function TablaDimensiones({ datos, dimensiones, keyResultado }: {
               })}
             </tr>
           ))}
+          <tr className="font-semibold bg-gray-100">
+            <td></td>
+            <td>Promedio</td>
+            <td></td>
+            {promedios.map((p, idx) => (
+              <td key={idx}>{p.promedio || ""}</td>
+            ))}
+          </tr>
+          <tr className="font-semibold bg-gray-100">
+            <td></td>
+            <td>Nivel</td>
+            <td></td>
+            {promedios.map((p, idx) => (
+              <td key={idx}>{p.nivel || ""}</td>
+            ))}
+          </tr>
         </tbody>
       </table>
     </div>

--- a/src/components/TablaDominios.tsx
+++ b/src/components/TablaDominios.tsx
@@ -1,6 +1,45 @@
-import React from "react";
+import React, { useMemo } from "react";
+import { baremosFormaA } from "@/data/baremosFormaA";
+import { baremosFormaB } from "@/data/baremosFormaB";
 
 export default function TablaDominios({ datos, dominios, keyResultado }: { datos: any[]; dominios: string[]; keyResultado: string }) {
+  const nivelesRiesgo = [
+    "Riesgo muy bajo",
+    "Riesgo bajo",
+    "Riesgo medio",
+    "Riesgo alto",
+    "Riesgo muy alto",
+  ];
+
+  const promedios = useMemo(() => {
+    const origen = keyResultado.toLowerCase().includes("formab") ? "formaB" : "formaA";
+    return dominios.map((dom) => {
+      const valores = datos
+        .map((d) => {
+          let seccion = d[keyResultado]?.dominios?.[dom];
+          if (Array.isArray(d[keyResultado]?.dominios)) {
+            seccion = d[keyResultado].dominios.find((x: any) => x.nombre === dom);
+          }
+          if (typeof seccion === "object") {
+            return seccion.transformado ?? seccion.puntajeTransformado;
+          }
+          return d[keyResultado]?.puntajesDominio?.[dom];
+        })
+        .filter((v: any) => typeof v === "number");
+      const prom = valores.length ? valores.reduce((a, b) => a + b, 0) / valores.length : 0;
+      const promedio = Math.round(prom * 10) / 10;
+      const baremos =
+        origen === "formaA"
+          ? (baremosFormaA.dominios as any)[dom] || []
+          : (baremosFormaB.dominio as any)[dom] || [];
+      const nivel =
+        baremos.find((b: any) => promedio >= b.min && promedio <= b.max)?.nivel || "No clasificado";
+      return {
+        promedio,
+        nivel: nivel === "Sin riesgo" ? "Riesgo muy bajo" : nivel,
+      };
+    });
+  }, [datos, dominios, keyResultado]);
   if (datos.length === 0) {
     return <div className="py-6 text-gray-400">No hay resultados de dominios para mostrar.</div>;
   }
@@ -37,6 +76,22 @@ export default function TablaDominios({ datos, dominios, keyResultado }: { datos
               })}
             </tr>
           ))}
+          <tr className="font-semibold bg-gray-100">
+            <td></td>
+            <td>Promedio</td>
+            <td></td>
+            {promedios.map((p, idx) => (
+              <td key={idx}>{p.promedio || ""}</td>
+            ))}
+          </tr>
+          <tr className="font-semibold bg-gray-100">
+            <td></td>
+            <td>Nivel</td>
+            <td></td>
+            {promedios.map((p, idx) => (
+              <td key={idx}>{p.nivel || ""}</td>
+            ))}
+          </tr>
         </tbody>
       </table>
     </div>

--- a/src/components/TablaIndividual.tsx
+++ b/src/components/TablaIndividual.tsx
@@ -1,6 +1,69 @@
-import React from "react";
+import React, { useMemo } from "react";
 
 export default function TablaIndividual({ datos, tipo }: { datos: any[]; tipo: string }) {
+  const promedios = useMemo(() => {
+    const nivelesRiesgo = [
+      "Riesgo muy bajo",
+      "Riesgo bajo",
+      "Riesgo medio",
+      "Riesgo alto",
+      "Riesgo muy alto",
+    ];
+    const nivelesEstres = ["Muy bajo", "Bajo", "Medio", "Alto", "Muy alto"];
+    const usarEstres = tipo === "estres";
+    const listaNiveles = usarEstres ? nivelesEstres : nivelesRiesgo;
+    let suma = 0;
+    let cuenta = 0;
+    const indices: number[] = [];
+    datos.forEach((d) => {
+      let puntaje: number | undefined;
+      let nivel: string | undefined;
+      if (tipo === "formaA") {
+        puntaje = d.resultadoFormaA?.total?.transformado;
+        nivel = d.resultadoFormaA?.total?.nivel;
+      } else if (tipo === "formaB") {
+        puntaje =
+          d.resultadoFormaB?.total?.transformado ??
+          d.resultadoFormaB?.puntajeTransformadoTotal ??
+          d.resultadoFormaB?.puntajeTransformado ??
+          d.resultadoFormaB?.puntajeTotalTransformado;
+        nivel =
+          d.resultadoFormaB?.total?.nivel ??
+          d.resultadoFormaB?.nivelTotal ??
+          d.resultadoFormaB?.nivel;
+      } else if (tipo === "extralaboral") {
+        puntaje = d.resultadoExtralaboral?.puntajeTransformadoTotal;
+        nivel = d.resultadoExtralaboral?.nivelGlobal;
+      } else if (tipo === "globalExtra") {
+        puntaje =
+          d.resultadoGlobalAExtralaboral?.puntajeGlobal ??
+          d.resultadoGlobalBExtralaboral?.puntajeGlobal;
+        nivel =
+          d.resultadoGlobalAExtralaboral?.nivelGlobal ??
+          d.resultadoGlobalBExtralaboral?.nivelGlobal;
+      } else if (tipo === "estres") {
+        puntaje = d.resultadoEstres?.puntajeTransformado;
+        nivel = d.resultadoEstres?.nivel;
+      }
+      if (typeof puntaje === "number") {
+        suma += puntaje;
+        cuenta += 1;
+      }
+      if (nivel) {
+        const n = nivel === "Sin riesgo" ? "Riesgo muy bajo" : nivel;
+        const idx = listaNiveles.indexOf(n);
+        if (idx >= 0) indices.push(idx);
+      }
+    });
+    const promPuntaje = cuenta ? Math.round((suma / cuenta) * 10) / 10 : "";
+    const promNivel =
+      indices.length > 0
+        ? listaNiveles[
+            Math.round(indices.reduce((a, b) => a + b, 0) / indices.length)
+          ]
+        : "";
+    return { puntaje: promPuntaje, nivel: promNivel };
+  }, [datos, tipo]);
   if (datos.length === 0) {
     return <div className="py-6 text-gray-400">No hay resultados individuales para mostrar.</div>;
   }
@@ -105,6 +168,44 @@ export default function TablaIndividual({ datos, tipo }: { datos: any[]; tipo: s
               <td>{d.fecha ? new Date(d.fecha).toLocaleString() : ""}</td>
             </tr>
           ))}
+          <tr className="font-semibold bg-gray-100">
+            <td></td>
+            <td>Promedio</td>
+            <td></td>
+            <td></td>
+            <td></td>
+            {tipo === "formaA" && (
+              <>
+                <td>{promedios.puntaje}</td>
+                <td>{promedios.nivel}</td>
+              </>
+            )}
+            {tipo === "formaB" && (
+              <>
+                <td>{promedios.puntaje}</td>
+                <td>{promedios.nivel}</td>
+              </>
+            )}
+            {tipo === "extralaboral" && (
+              <>
+                <td>{promedios.puntaje}</td>
+                <td>{promedios.nivel}</td>
+              </>
+            )}
+            {tipo === "globalExtra" && (
+              <>
+                <td>{promedios.puntaje}</td>
+                <td>{promedios.nivel}</td>
+              </>
+            )}
+            {tipo === "estres" && (
+              <>
+                <td>{promedios.puntaje}</td>
+                <td>{promedios.nivel}</td>
+              </>
+            )}
+            <td></td>
+          </tr>
         </tbody>
       </table>
     </div>


### PR DESCRIPTION
## Summary
- compute average puntaje and risk level for each domain and dimension
- show final rows with averages and levels in domain and dimension tables

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails to find React and other dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68546d6f878883319f13ef74e900cd0c