### PR TITLE
Add Psykhe logo on homepage

### DIFF
--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import LogoCogent from "../logo_texto.png";
 
+// Logo of Psykhe Consultores is served from the public directory
+
 type Props = {
   onStartSurvey: () => void;
   onViewResults: () => void;
@@ -25,12 +27,20 @@ export default function HomePage({ onStartSurvey, onViewResults, onPrivacy }: Pr
         </defs>
       </svg>
 
-      <img
-        src={LogoCogent}
-        alt="COGENT Logo"
-        className="w-28 h-28 mb-8 drop-shadow-lg animate-fadeIn"
-        style={{ borderRadius: '18px' }}
-      />
+      <div className="flex items-center justify-center gap-6 mb-8 animate-fadeIn">
+        <img
+          src="/Logo_Psykhe.png"
+          alt="Psykhe Consultores Logo"
+          className="w-28 h-28 drop-shadow-lg"
+          style={{ borderRadius: '18px' }}
+        />
+        <img
+          src={LogoCogent}
+          alt="COGENT Logo"
+          className="w-28 h-28 drop-shadow-lg"
+          style={{ borderRadius: '18px' }}
+        />
+      </div>
 
       <h1 className="text-4xl md:text-5xl font-bold text-[#132045] text-center mb-2 font-montserrat animate-fadeIn">
         Bienvenido a Cogent


### PR DESCRIPTION
## Summary
- display the Psykhe Consultores logo beside the Cogent logo on the home page
- give the Psykhe logo the same rounded style and dimensions as the Cogent logo

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6854d66bc2b48331b18c6e3bd265ef3c