### PR TITLE
Fix TypeScript warnings

### DIFF
--- a/src/components/AdminEmpresas.tsx
+++ b/src/components/AdminEmpresas.tsx
@@ -44,7 +44,12 @@ export default function AdminEmpresas({
   const handleGuardarEdicion = () => {
     if (editIndex === null) return;
     if (!editUsuario.trim() || !editPassword.trim()) return;
-    onEditar(editIndex, editUsuario.trim(), editPassword.trim());
+    onEditar(
+      credenciales[editIndex].usuario,
+      credenciales[editIndex].empresa,
+      editUsuario.trim(),
+      editPassword.trim()
+    );
     setEditIndex(null);
     setEditUsuario("");
     setEditPassword("");

--- a/src/components/BloquesDePreguntas.tsx
+++ b/src/components/BloquesDePreguntas.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 
 type Bloque = {
   bloque: number;
-  preguntas: [number, number]; // índices de inicio y fin (INCLUSIVO)
+  preguntas: number[]; // índices de inicio y fin (INCLUSIVO)
   enunciado: string;
   condicional?: string | null; // "F1", "F2", "F3" o null
   obligatorio: boolean;
@@ -10,7 +10,7 @@ type Bloque = {
 
 type Pregunta = {
   texto: string;
-  tipo: "likert" | "yesno" | "estres";
+  tipo: string; // "likert" | "yesno" | "estres"
   filtro?: boolean; // true si es pregunta filtro (sí/no)
 };
 
@@ -29,11 +29,11 @@ export default function BloquesDePreguntas({ bloques, preguntas, onFinish }: Pro
     // Buscar el bloque condicional correspondiente
     const bloqueFiltro = bloques.find(b => b.condicional === null && b.enunciado.toLowerCase().includes(nombre.toLowerCase()));
     // Si no está enunciado el nombre, buscar por orden fijo
-    let idx = null;
+    let idx: number | null = null;
     if (nombre === "F1") idx = 104;
     if (nombre === "F2") idx = 114;
     if (nombre === "F3") idx = 88;
-    return respuestas[idx];
+    return idx !== null ? respuestas[idx] : undefined;
   };
 
   // Valida si el bloque debe mostrarse según condicional

--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -136,7 +136,9 @@ export default function DashboardResultados({
   const [empresaEliminar, setEmpresaEliminar] = useState("todas");
   const [tab, setTab] = useState("general");
   const [tabGeneral, setTabGeneral] = useState("resumen");
-  const [categoriaFicha, setCategoriaFicha] = useState(categoriasFicha[0].key);
+  const [categoriaFicha, setCategoriaFicha] = useState<string>(
+    categoriasFicha[0].key
+  );
   const [tabIntra, setTabIntra] = useState("global"); // Para sub-tabs de formaA/B
 
   const [tabExtra, setTabExtra] = useState("global");
@@ -651,7 +653,7 @@ export default function DashboardResultados({
             resumenExtra={resumenExtra}
             resumenEstres={resumenEstres}
             categoriaFicha={categoriaFicha}
-            onCategoriaChange={setCategoriaFicha}
+            onCategoriaChange={(v) => setCategoriaFicha(v)}
             categoriasFicha={categoriasFicha}
             fichaConteos={fichaConteosGlobal}
           />
@@ -756,7 +758,11 @@ export default function DashboardResultados({
                 <div className="text-[var(--gray-medium)] py-4">No hay resultados Globales A.</div>
               ) : (
                 <>
-                  <GraficaBarraSimple resumen={resumenGlobalAE} titulo="Niveles Global A + Extra" />
+                  <GraficaBarraSimple
+                    resumen={resumenGlobalAE}
+                    titulo="Niveles Global A + Extra"
+                    chartType={chartType}
+                  />
                   {!soloGenerales && <TablaIndividual datos={datosGlobalAE} tipo="globalExtra" />}
                 </>
               )}
@@ -766,7 +772,11 @@ export default function DashboardResultados({
                 <div className="text-[var(--gray-medium)] py-4">No hay resultados Globales B.</div>
               ) : (
                 <>
-                  <GraficaBarraSimple resumen={resumenGlobalBE} titulo="Niveles Global B + Extra" />
+                  <GraficaBarraSimple
+                    resumen={resumenGlobalBE}
+                    titulo="Niveles Global B + Extra"
+                    chartType={chartType}
+                  />
                   {!soloGenerales && <TablaIndividual datos={datosGlobalBE} tipo="globalExtra" />}
                 </>
               )}

--- a/src/components/Encuesta.tsx
+++ b/src/components/Encuesta.tsx
@@ -53,13 +53,15 @@ export default function Encuesta({ tipo = "A" }: { tipo?: TipoFormulario }) {
       ));
 
   // ¿Hay un filtro entre bloques?
-  const filtroBloque =
-    tipo === "A"
-      ? (bloqueActual === 13 && preguntas[105]) || // F1
-        (bloqueActual === 14 && preguntas[115])    // F2
-      : tipo === "B"
-        ? bloqueActual === 12 && preguntas[88]     // F3
-        : null;
+  const filtroBloque = (() => {
+    if (tipo === "A") {
+      if (bloqueActual === 13) return { ...preguntas[105], key: "F1" };
+      if (bloqueActual === 14) return { ...preguntas[115], key: "F2" };
+    } else if (tipo === "B" && bloqueActual === 12) {
+      return { ...preguntas[88], key: "F3" };
+    }
+    return null;
+  })();
 
   // Render
   return (
@@ -75,8 +77,18 @@ export default function Encuesta({ tipo = "A" }: { tipo?: TipoFormulario }) {
       {filtroBloque && (
         <div className="my-6">
           <p className="font-bold">{filtroBloque.texto}</p>
-          <button onClick={() => responderFiltro(filtroBloque.filtro, true)} className="mr-2 bg-primary-main text-white p-2 rounded">Sí</button>
-          <button onClick={() => responderFiltro(filtroBloque.filtro, false)} className="bg-primary-main text-white p-2 rounded">No</button>
+          <button
+            onClick={() => responderFiltro(filtroBloque.key, true)}
+            className="mr-2 bg-primary-main text-white p-2 rounded"
+          >
+            Sí
+          </button>
+          <button
+            onClick={() => responderFiltro(filtroBloque.key, false)}
+            className="bg-primary-main text-white p-2 rounded"
+          >
+            No
+          </button>
         </div>
       )}
 

--- a/src/components/FichaDatosGenerales.tsx
+++ b/src/components/FichaDatosGenerales.tsx
@@ -68,10 +68,18 @@ export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Pr
 
   const [error, setError] = useState<string>("");
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
-    const { name, value, type, checked } = e.target;
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
+  ) => {
+    const { name, value, type } = e.target;
+    const checked = (e.target as HTMLInputElement).checked;
     if (type === "checkbox") {
-      setDatos({ ...datos, [name]: checked, ...(name === "menosAnioEmpresa" && checked ? { aniosEmpresa: "" } : {}), ...(name === "menosAnioCargo" && checked ? { aniosCargo: "" } : {}) });
+      setDatos({
+        ...datos,
+        [name]: checked,
+        ...(name === "menosAnioEmpresa" && checked ? { aniosEmpresa: "" } : {}),
+        ...(name === "menosAnioCargo" && checked ? { aniosCargo: "" } : {}),
+      });
     } else {
       setDatos({ ...datos, [name]: value });
     }

--- a/src/components/dashboard/GeneralResultsTabs.tsx
+++ b/src/components/dashboard/GeneralResultsTabs.tsx
@@ -35,7 +35,7 @@ export default function GeneralResultsTabs({
   resumenEstres: any[];
   categoriaFicha: string;
   onCategoriaChange: (v: string) => void;
-  categoriasFicha: CategoriaFicha[];
+  categoriasFicha: readonly CategoriaFicha[];
   fichaConteos: Record<string, any[]>;
 }) {
   return (

--- a/src/data/esquemaExtralaboral.ts
+++ b/src/data/esquemaExtralaboral.ts
@@ -9,14 +9,14 @@ export const preguntasInverso = [
 ];
 
 // Cómo se puntúan las respuestas
-export const puntajeDirecto = {
+export const puntajeDirecto: Record<string, number> = {
   "siempre": 0,
   "casi siempre": 1,
   "algunas veces": 2,
   "casi nunca": 3,
   "nunca": 4
 };
-export const puntajeInverso = {
+export const puntajeInverso: Record<string, number> = {
   "siempre": 4,
   "casi siempre": 3,
   "algunas veces": 2,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
-import App from './App.tsx'
+import App from './App'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>


### PR DESCRIPTION
## Summary
- adjust `BloquesDePreguntas` types and null checks
- fix AdminEmpresas onEditar arguments
- handle category state generics and chartType props in Dashboard
- update filter logic in Encuesta
- handle checkbox events in FichaDatosGenerales
- allow indexing of scoring maps
- fix App import path

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react', '@radix-ui/react-tabs', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6856214d16d0833198e3541dbd7cbf57