### PR TITLE
Type baremo arrays

### DIFF
--- a/src/utils/calcularFormaA.ts
+++ b/src/utils/calcularFormaA.ts
@@ -4,6 +4,12 @@ import { baremosFormaA } from "../data/baremosFormaA";
 
 type Respuestas = string[];
 
+interface Baremo {
+  nivel: string;
+  min: number;
+  max: number;
+}
+
 // Preguntas con esquema directo e inverso
 const directas = new Set(
   esquemaFormaA.filter(q => q.esquema === "directo").map(q => q.numero)
@@ -64,12 +70,12 @@ export function calcularFormaA(respuestas: Respuestas) {
         dimension as keyof typeof factoresFormaA.dimensiones
       ] ?? preguntas.length;
     const transformado = Math.round(((suma * 100) / factor) * 10) / 10;
-    const baremo =
+    const baremo: Baremo[] =
       baremosFormaA.dimensiones[
         dimension as keyof typeof baremosFormaA.dimensiones
       ] || [];
     const nivel =
-      baremo.find((b: any) => transformado >= b.min && transformado <= b.max)?.nivel ||
+      baremo.find((b: Baremo) => transformado >= b.min && transformado <= b.max)?.nivel ||
       "No clasificado";
     resultadoDimensiones[dimension] = { suma, transformado, nivel };
   });
@@ -85,12 +91,12 @@ export function calcularFormaA(respuestas: Respuestas) {
         dominio as keyof typeof factoresFormaA.dominios
       ] ?? preguntas.length;
     const transformado = Math.round(((suma * 100) / factor) * 10) / 10;
-    const baremo =
+    const baremo: Baremo[] =
       baremosFormaA.dominios[
         dominio as keyof typeof baremosFormaA.dominios
       ] || [];
     const nivel =
-      baremo.find((b: any) => transformado >= b.min && transformado <= b.max)?.nivel ||
+      baremo.find((b: Baremo) => transformado >= b.min && transformado <= b.max)?.nivel ||
       "No clasificado";
     resultadoDominios[dominio] = { suma, transformado, nivel };
   });
@@ -101,7 +107,7 @@ export function calcularFormaA(respuestas: Respuestas) {
   );
   const totalTransformado = Math.round((sumaTotal * 100 / factoresFormaA.total) * 10) / 10;
   const baremoTotal = baremosFormaA.total.find(
-    b => totalTransformado >= b.min && totalTransformado <= b.max
+    (b: Baremo) => totalTransformado >= b.min && totalTransformado <= b.max
   );
 
   return {

--- a/src/utils/calcularFormaB.ts
+++ b/src/utils/calcularFormaB.ts
@@ -2,6 +2,12 @@ import { esquemaFormaB } from "../data/esquemaFormaB";
 import { factoresFormaB } from "../data/factoresFormaB";
 import { baremosFormaB } from "../data/baremosFormaB";
 
+interface Baremo {
+  nivel: string;
+  min: number;
+  max: number;
+}
+
 // Mapeo para esquema de puntaje directo e inverso
 const directas = new Set(esquemaFormaB.filter(q => q.esquema === "directo").map(q => q.numero));
 const inversas = new Set(esquemaFormaB.filter(q => q.esquema === "inverso").map(q => q.numero));
@@ -65,12 +71,12 @@ export function calcularFormaB(respuestas: string[]) {
         dimension as keyof typeof factoresFormaB.dimension
       ] ?? preguntas.length;
     const transformado = Math.round(((suma * 100) / factor) * 10) / 10;
-    const baremo =
+    const baremo: Baremo[] =
       baremosFormaB.dimension[
         dimension as keyof typeof baremosFormaB.dimension
       ] || [];
     const nivel =
-      baremo.find((b: any) => transformado >= b.min && transformado <= b.max)?.nivel ||
+      baremo.find((b: Baremo) => transformado >= b.min && transformado <= b.max)?.nivel ||
       "No clasificado";
     resultadosDimension[dimension] = { suma, transformado, nivel };
   });
@@ -87,12 +93,12 @@ export function calcularFormaB(respuestas: string[]) {
         dominio as keyof typeof factoresFormaB.dominio
       ] ?? preguntas.length;
     const transformado = Math.round(((suma * 100) / factor) * 10) / 10;
-    const baremo =
+    const baremo: Baremo[] =
       baremosFormaB.dominio[
         dominio as keyof typeof baremosFormaB.dominio
       ] || [];
     const nivel =
-      baremo.find((b: any) => transformado >= b.min && transformado <= b.max)?.nivel ||
+      baremo.find((b: Baremo) => transformado >= b.min && transformado <= b.max)?.nivel ||
       "No clasificado";
     resultadosDominio[dominio] = { suma, transformado, nivel };
   });
@@ -105,8 +111,8 @@ export function calcularFormaB(respuestas: string[]) {
   const puntajeTotal = Math.round((sumaTotal * 100 / factoresFormaB.total) * 10) / 10;
 
   // Nivel total
-  const baremoTotal = baremosFormaB.total || [];
-  const nivelTotal = baremoTotal.find(b => puntajeTotal >= b.min && puntajeTotal <= b.max)?.nivel || "No clasificado";
+  const baremoTotal: Baremo[] = baremosFormaB.total || [];
+  const nivelTotal = baremoTotal.find((b: Baremo) => puntajeTotal >= b.min && puntajeTotal <= b.max)?.nivel || "No clasificado";
 
   return {
     dimensiones: resultadosDimension,

--- a/src/utils/calcularGlobalA.ts
+++ b/src/utils/calcularGlobalA.ts
@@ -1,7 +1,13 @@
 // src/utils/calcularGlobalA.ts
 
 // Baremos para el global A + extralaboral
-export const baremoGlobalAExtrala = [
+interface Baremo {
+  nivel: string;
+  min: number;
+  max: number;
+}
+
+export const baremoGlobalAExtrala: Baremo[] = [
   { nivel: "Sin riesgo", min: 0.0, max: 18.8 },
   { nivel: "Riesgo bajo", min: 18.9, max: 24.4 },
   { nivel: "Riesgo medio", min: 24.5, max: 29.5 },
@@ -19,7 +25,9 @@ export function calcularGlobalAExtrala(
   global = Math.round(global * 10) / 10;
   if (global < 0) global = 0;
   if (global > 100) global = 100;
-  const baremo = baremoGlobalAExtrala.find(b => global >= b.min && global <= b.max);
+  const baremo = baremoGlobalAExtrala.find(
+    (b: Baremo) => global >= b.min && global <= b.max
+  );
   return {
     puntajeGlobal: global,
     nivelGlobal: baremo?.nivel ?? "No clasificado"
@@ -40,8 +48,9 @@ export function calcularGlobalBExtrala(
   global = Math.round(global * 10) / 10;
   if (global < 0) global = 0;
   if (global > 100) global = 100;
-  const baremo = baremosFormaB.global.find(
-    (b: any) => global >= b.min && global <= b.max
+  const baremosGlobal: Baremo[] = baremosFormaB.global;
+  const baremo = baremosGlobal.find(
+    (b: Baremo) => global >= b.min && global <= b.max
   );
   return {
     puntajeGlobal: global,


### PR DESCRIPTION
## Summary
- add `Baremo` interface in calculation utilities
- apply `Baremo[]` to arrays of baremos
- type `.find` callbacks with `Baremo`

## Testing
- `npm run build` *(fails: Cannot find module 'react' and other deps)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68562d15e2ec83318a786a704f319d33