### PR TITLE
Add NivelResumen interface and type chart data

### DIFF
--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -13,7 +13,7 @@ import TablaDimensiones from "@/components/TablaDimensiones";
 import GraficaBarra from "@/components/GraficaBarra";
 import GraficaBarraSimple from "@/components/GraficaBarraSimple";
 import AdminEmpresas from "@/components/AdminEmpresas";
-import { CredencialEmpresa } from "@/types";
+import { CredencialEmpresa, NivelResumen } from "@/types";
 import GeneralResultsTabs from "@/components/dashboard/GeneralResultsTabs";
 import FormaTabs from "@/components/dashboard/FormaTabs";
 import LogoCogent from "/logo_forma.png";
@@ -194,14 +194,23 @@ export default function DashboardResultados({
   const datosGlobalBE = datosMostrados.filter((d) => d.resultadoGlobalBExtralaboral);
 
   // ---- Resúmenes para gráficos ----
-  const resumenNivel = (datos: any[], key: string, niveles: string[]) =>
-    niveles.map((nivel) => ({
+  const resumenNivel = (
+    datos: any[],
+    key: string,
+    niveles: string[]
+  ): (NivelResumen & { cantidad: number })[] =>
+    niveles.map((nivel, indice) => ({
+      nombre: nivel,
+      indice,
       nivel,
       cantidad: datos.filter((d) => {
         const r = d[key];
         const nivelRes =
           r?.total?.nivel ?? r?.nivelTotal ?? r?.nivelGlobal ?? r?.nivel;
-        return nivelRes === nivel || (nivelRes === "Sin riesgo" && nivel === "Riesgo muy bajo");
+        return (
+          nivelRes === nivel ||
+          (nivelRes === "Sin riesgo" && nivel === "Riesgo muy bajo")
+        );
       }).length,
     }));
 

--- a/src/components/GraficaBarra.tsx
+++ b/src/components/GraficaBarra.tsx
@@ -1,5 +1,18 @@
 import React from "react";
-import { BarChart, Bar, PieChart, Pie, Cell, XAxis, YAxis, Tooltip, Legend, ResponsiveContainer, LabelList } from "recharts";
+import {
+  BarChart,
+  Bar,
+  PieChart,
+  Pie,
+  Cell,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+  LabelList,
+} from "recharts";
+import { NivelResumen } from "@/types";
 
 const gradientes = {
   "Riesgo muy bajo": { id: "riesgo-muy-bajo", from: "#bfdbfe", to: "#3b82f6" },
@@ -27,7 +40,7 @@ export default function GraficaBarra({
   titulo,
   chartType,
 }: {
-  resumen: any[];
+  resumen: NivelResumen[];
   titulo: string;
   chartType: "bar" | "histogram" | "pie";
 }) {

--- a/src/components/GraficaBarraSimple.tsx
+++ b/src/components/GraficaBarraSimple.tsx
@@ -12,6 +12,7 @@ import {
   ResponsiveContainer,
   LabelList,
 } from "recharts";
+import { NivelResumen } from "@/types";
 
 const gradientes = {
 
@@ -39,7 +40,7 @@ export default function GraficaBarraSimple({
   titulo,
   chartType,
 }: {
-  resumen: any[];
+  resumen: (NivelResumen & { cantidad: number })[];
   titulo: string;
   chartType: "bar" | "histogram" | "pie";
 }) {

--- a/src/components/dashboard/FormaTabs.tsx
+++ b/src/components/dashboard/FormaTabs.tsx
@@ -5,6 +5,7 @@ import GraficaBarra from "@/components/GraficaBarra";
 import TablaIndividual from "@/components/TablaIndividual";
 import TablaDominios from "@/components/TablaDominios";
 import TablaDimensiones from "@/components/TablaDimensiones";
+import { NivelResumen } from "@/types";
 
 export default function FormaTabs({
   value,
@@ -24,9 +25,9 @@ export default function FormaTabs({
   value: string;
   onChange: (v: string) => void;
   datos: any[];
-  resumen: any[];
-  promediosDominios: any[];
-  promediosDimensiones: any[];
+  resumen: (NivelResumen & { cantidad: number })[];
+  promediosDominios: NivelResumen[];
+  promediosDimensiones: NivelResumen[];
   dominios: string[];
   dimensiones: string[];
   chartType: "bar" | "histogram" | "pie";

--- a/src/components/dashboard/GeneralResultsTabs.tsx
+++ b/src/components/dashboard/GeneralResultsTabs.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import GraficaBarraSimple from "@/components/GraficaBarraSimple";
 import FichaTecnicaTabs, { CategoriaFicha } from "./FichaTecnicaTabs";
+import { NivelResumen } from "@/types";
 
 export default function GeneralResultsTabs({
   value,
@@ -29,10 +30,10 @@ export default function GeneralResultsTabs({
   datosB: any[];
   datosExtra: any[];
   datosEstres: any[];
-  resumenA: any[];
-  resumenB: any[];
-  resumenExtra: any[];
-  resumenEstres: any[];
+  resumenA: (NivelResumen & { cantidad: number })[];
+  resumenB: (NivelResumen & { cantidad: number })[];
+  resumenExtra: (NivelResumen & { cantidad: number })[];
+  resumenEstres: (NivelResumen & { cantidad: number })[];
   categoriaFicha: string;
   onCategoriaChange: (v: string) => void;
   categoriasFicha: readonly CategoriaFicha[];

--- a/src/types/NivelResumen.ts
+++ b/src/types/NivelResumen.ts
@@ -1,0 +1,5 @@
+export interface NivelResumen {
+  nombre: string;
+  indice: number;
+  nivel: string;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,1 +1,2 @@
 export * from './CredencialEmpresa';
+export * from './NivelResumen';


### PR DESCRIPTION
## Summary
- define `NivelResumen` interface for chart data
- use `NivelResumen` in GraficaBarra components and dashboard tabs
- update summary creation to include new fields

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68562d3728f083319ef682d5648c8028