### PR TITLE
Type baremos and dataset rows

### DIFF
--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -13,7 +13,7 @@ import TablaDimensiones from "@/components/TablaDimensiones";
 import GraficaBarra from "@/components/GraficaBarra";
 import GraficaBarraSimple from "@/components/GraficaBarraSimple";
 import AdminEmpresas from "@/components/AdminEmpresas";
-import { CredencialEmpresa } from "@/types";
+import { CredencialEmpresa, ResultRow } from "@/types";
 import GeneralResultsTabs from "@/components/dashboard/GeneralResultsTabs";
 import FormaTabs from "@/components/dashboard/FormaTabs";
 import LogoCogent from "/logo_forma.png";
@@ -131,7 +131,7 @@ export default function DashboardResultados({
   onEditarEmpresa,
   onBack
 }: Props) {
-  const [datos, setDatos] = useState<any[]>([]);
+  const [datos, setDatos] = useState<ResultRow[]>([]);
   const [empresaSeleccionada, setEmpresaSeleccionada] = useState(empresaFiltro || "todas");
   const [empresaEliminar, setEmpresaEliminar] = useState("todas");
   const [tab, setTab] = useState("general");
@@ -194,7 +194,7 @@ export default function DashboardResultados({
   const datosGlobalBE = datosMostrados.filter((d) => d.resultadoGlobalBExtralaboral);
 
   // ---- Resúmenes para gráficos ----
-  const resumenNivel = (datos: any[], key: string, niveles: string[]) =>
+  const resumenNivel = (datos: ResultRow[], key: string, niveles: string[]) =>
     niveles.map((nivel) => ({
       nivel,
       cantidad: datos.filter((d) => {
@@ -219,20 +219,20 @@ export default function DashboardResultados({
     valor: number,
     origen: "formaA" | "formaB" | "extra",
     tipo: "dimensiones" | "dominios",
-    datos?: any[]
+    datos?: ResultRow[]
   ) {
     let baremo: { nivel: string; min: number; max: number }[] = [];
     if (origen === "formaA") {
       if (tipo === "dimensiones") {
-        baremo = (baremosFormaA.dimensiones as any)[nombre] || [];
+        baremo = baremosFormaA.dimensiones[nombre] || [];
       } else {
-        baremo = (baremosFormaA.dominios as any)[nombre] || [];
+        baremo = baremosFormaA.dominios[nombre] || [];
       }
     } else if (origen === "formaB") {
       if (tipo === "dimensiones") {
-        baremo = (baremosFormaB.dimension as any)[nombre] || [];
+        baremo = baremosFormaB.dimension[nombre] || [];
       } else {
-        baremo = (baremosFormaB.dominio as any)[nombre] || [];
+        baremo = baremosFormaB.dominio[nombre] || [];
       }
     } else if (origen === "extra") {
       if (datos && datos.length) {
@@ -269,7 +269,7 @@ export default function DashboardResultados({
   }
 
   function calcularPromedios(
-    datos: any[],
+    datos: ResultRow[],
     key: string,
     campos: string[],
     subkey: "dominios" | "dimensiones",
@@ -353,7 +353,7 @@ export default function DashboardResultados({
 
 
 
-  function conteosPorFicha(datos: any[], keyFicha: string) {
+  function conteosPorFicha(datos: ResultRow[], keyFicha: string) {
     if (keyFicha === "antiguedad") {
       const grupos = Array.from(
         new Set(

--- a/src/components/TablaDimensiones.tsx
+++ b/src/components/TablaDimensiones.tsx
@@ -1,8 +1,9 @@
 import React, { useMemo } from "react";
 import { baremosFormaA } from "@/data/baremosFormaA";
 import { baremosFormaB } from "@/data/baremosFormaB";
+import { ResultRow } from "@/types";
 
-export default function TablaDimensiones({ datos, dimensiones, keyResultado }: { datos: any[]; dimensiones: string[]; keyResultado: string }) {
+export default function TablaDimensiones({ datos, dimensiones, keyResultado }: { datos: ResultRow[]; dimensiones: string[]; keyResultado: string }) {
   const nivelesRiesgo = [
     "Riesgo muy bajo",
     "Riesgo bajo",
@@ -30,8 +31,8 @@ export default function TablaDimensiones({ datos, dimensiones, keyResultado }: {
       const promedio = Math.round(prom * 10) / 10;
       const baremos =
         origen === "formaA"
-          ? (baremosFormaA.dimensiones as any)[dim] || []
-          : (baremosFormaB.dimension as any)[dim] || [];
+          ? baremosFormaA.dimensiones[dim] || []
+          : baremosFormaB.dimension[dim] || [];
       const nivel =
         baremos.find((b: any) => promedio >= b.min && promedio <= b.max)?.nivel || "No clasificado";
       return {

--- a/src/components/TablaDominios.tsx
+++ b/src/components/TablaDominios.tsx
@@ -1,8 +1,9 @@
 import React, { useMemo } from "react";
 import { baremosFormaA } from "@/data/baremosFormaA";
 import { baremosFormaB } from "@/data/baremosFormaB";
+import { ResultRow } from "@/types";
 
-export default function TablaDominios({ datos, dominios, keyResultado }: { datos: any[]; dominios: string[]; keyResultado: string }) {
+export default function TablaDominios({ datos, dominios, keyResultado }: { datos: ResultRow[]; dominios: string[]; keyResultado: string }) {
   const nivelesRiesgo = [
     "Riesgo muy bajo",
     "Riesgo bajo",
@@ -30,8 +31,8 @@ export default function TablaDominios({ datos, dominios, keyResultado }: { datos
       const promedio = Math.round(prom * 10) / 10;
       const baremos =
         origen === "formaA"
-          ? (baremosFormaA.dominios as any)[dom] || []
-          : (baremosFormaB.dominio as any)[dom] || [];
+          ? baremosFormaA.dominios[dom] || []
+          : baremosFormaB.dominio[dom] || [];
       const nivel =
         baremos.find((b: any) => promedio >= b.min && promedio <= b.max)?.nivel || "No clasificado";
       return {

--- a/src/components/TablaIndividual.tsx
+++ b/src/components/TablaIndividual.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from "react";
+import { ResultRow } from "@/types";
 
-export default function TablaIndividual({ datos, tipo }: { datos: any[]; tipo: string }) {
+export default function TablaIndividual({ datos, tipo }: { datos: ResultRow[]; tipo: string }) {
   const promedios = useMemo(() => {
     const nivelesRiesgo = [
       "Riesgo muy bajo",

--- a/src/components/dashboard/FormaTabs.tsx
+++ b/src/components/dashboard/FormaTabs.tsx
@@ -5,6 +5,7 @@ import GraficaBarra from "@/components/GraficaBarra";
 import TablaIndividual from "@/components/TablaIndividual";
 import TablaDominios from "@/components/TablaDominios";
 import TablaDimensiones from "@/components/TablaDimensiones";
+import { ResultRow } from "@/types";
 
 export default function FormaTabs({
   value,
@@ -23,7 +24,7 @@ export default function FormaTabs({
 }: {
   value: string;
   onChange: (v: string) => void;
-  datos: any[];
+  datos: ResultRow[];
   resumen: any[];
   promediosDominios: any[];
   promediosDimensiones: any[];

--- a/src/data/baremosFormaA.ts
+++ b/src/data/baremosFormaA.ts
@@ -1,6 +1,13 @@
 // src/data/baremosFormaA.ts
+import { Baremo } from "@/types";
 
-export const baremosFormaA = {
+export interface BaremosFormaA {
+  total: Baremo[];
+  dominios: Record<string, Baremo[]>;
+  dimensiones: Record<string, Baremo[]>;
+}
+
+export const baremosFormaA: BaremosFormaA = {
   // Puntaje total intralaboral
   total: [
     { nivel: "Sin riesgo", min: 0.0, max: 19.7 },

--- a/src/data/baremosFormaB.ts
+++ b/src/data/baremosFormaB.ts
@@ -1,6 +1,14 @@
 // src/data/baremosFormaB.ts
+import { Baremo } from "@/types";
 
-export const baremosFormaB = {
+export interface BaremosFormaB {
+  dimension: Record<string, Baremo[]>;
+  dominio: Record<string, Baremo[]>;
+  total: Baremo[];
+  global: Baremo[];
+}
+
+export const baremosFormaB: BaremosFormaB = {
   dimension: {
     "Características del liderazgo": [
       { nivel: "Sin riesgo", min: 0.0, max: 3.8 },

--- a/src/types/Resultados.ts
+++ b/src/types/Resultados.ts
@@ -1,0 +1,86 @@
+export interface Baremo {
+  nivel: string;
+  min: number;
+  max: number;
+}
+
+export interface DimensionResultado {
+  suma: number;
+  transformado: number;
+  nivel: string;
+}
+
+export interface IntralaboralResultado {
+  dimensiones: Record<string, DimensionResultado>;
+  dominios: Record<string, DimensionResultado>;
+  total: DimensionResultado & { suma: number };
+}
+
+export interface ExtralaboralDimensionResultado {
+  nombre: string;
+  puntajeBruto: number;
+  puntajeTransformado: number;
+  nivel: string;
+}
+
+export interface ExtralaboralResultado {
+  valido: boolean;
+  dimensiones: ExtralaboralDimensionResultado[];
+  puntajeBrutoTotal: number;
+  puntajeTransformadoTotal: number;
+  nivelGlobal: string;
+}
+
+export interface GlobalResultado {
+  puntajeGlobal: number;
+  nivelGlobal: string;
+}
+
+export interface EstresResultado {
+  valido: boolean;
+  puntajeBruto: number;
+  puntajeTransformado: number;
+  nivel: string;
+}
+
+export interface FichaDatosGenerales {
+  fecha: string;
+  nombre: string;
+  cedula: string;
+  sexo: string;
+  nacimiento: string;
+  estadoCivil: string;
+  estudios: string;
+  ocupacion: string;
+  residenciaCiudad: string;
+  residenciaDepto: string;
+  estrato: string;
+  vivienda: string;
+  dependientes: string;
+  trabajoCiudad: string;
+  trabajoDepto: string;
+  aniosEmpresa: string;
+  menosAnioEmpresa: boolean;
+  cargo: string;
+  tipoCargo: string;
+  aniosCargo: string;
+  menosAnioCargo: boolean;
+  area: string;
+  tipoContrato: string;
+  horasDiarias: string;
+  tipoSalario: string;
+  empresa?: string;
+}
+
+export interface ResultRow {
+  ficha?: FichaDatosGenerales;
+  respuestas?: any;
+  resultadoFormaA?: IntralaboralResultado;
+  resultadoFormaB?: IntralaboralResultado;
+  resultadoExtralaboral?: ExtralaboralResultado;
+  resultadoGlobalAExtralaboral?: GlobalResultado;
+  resultadoGlobalBExtralaboral?: GlobalResultado;
+  resultadoEstres?: EstresResultado;
+  tipo: "A" | "B";
+  fecha: string;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,1 +1,2 @@
 export * from './CredencialEmpresa';
+export * from './Resultados';

--- a/src/utils/calcularFormaA.ts
+++ b/src/utils/calcularFormaA.ts
@@ -64,10 +64,7 @@ export function calcularFormaA(respuestas: Respuestas) {
         dimension as keyof typeof factoresFormaA.dimensiones
       ] ?? preguntas.length;
     const transformado = Math.round(((suma * 100) / factor) * 10) / 10;
-    const baremo =
-      baremosFormaA.dimensiones[
-        dimension as keyof typeof baremosFormaA.dimensiones
-      ] || [];
+    const baremo = baremosFormaA.dimensiones[dimension] || [];
     const nivel =
       baremo.find((b: any) => transformado >= b.min && transformado <= b.max)?.nivel ||
       "No clasificado";
@@ -85,10 +82,7 @@ export function calcularFormaA(respuestas: Respuestas) {
         dominio as keyof typeof factoresFormaA.dominios
       ] ?? preguntas.length;
     const transformado = Math.round(((suma * 100) / factor) * 10) / 10;
-    const baremo =
-      baremosFormaA.dominios[
-        dominio as keyof typeof baremosFormaA.dominios
-      ] || [];
+    const baremo = baremosFormaA.dominios[dominio] || [];
     const nivel =
       baremo.find((b: any) => transformado >= b.min && transformado <= b.max)?.nivel ||
       "No clasificado";

--- a/src/utils/calcularFormaB.ts
+++ b/src/utils/calcularFormaB.ts
@@ -65,10 +65,7 @@ export function calcularFormaB(respuestas: string[]) {
         dimension as keyof typeof factoresFormaB.dimension
       ] ?? preguntas.length;
     const transformado = Math.round(((suma * 100) / factor) * 10) / 10;
-    const baremo =
-      baremosFormaB.dimension[
-        dimension as keyof typeof baremosFormaB.dimension
-      ] || [];
+    const baremo = baremosFormaB.dimension[dimension] || [];
     const nivel =
       baremo.find((b: any) => transformado >= b.min && transformado <= b.max)?.nivel ||
       "No clasificado";
@@ -87,10 +84,7 @@ export function calcularFormaB(respuestas: string[]) {
         dominio as keyof typeof factoresFormaB.dominio
       ] ?? preguntas.length;
     const transformado = Math.round(((suma * 100) / factor) * 10) / 10;
-    const baremo =
-      baremosFormaB.dominio[
-        dominio as keyof typeof baremosFormaB.dominio
-      ] || [];
+    const baremo = baremosFormaB.dominio[dominio] || [];
     const nivel =
       baremo.find((b: any) => transformado >= b.min && transformado <= b.max)?.nivel ||
       "No clasificado";


### PR DESCRIPTION
## Summary
- define `ResultRow` and related interfaces in `src/types/Resultados.ts`
- export new types from `src/types/index.ts`
- type `baremosFormaA` and `baremosFormaB`
- replace `any[]` parameters with `ResultRow[]`
- remove baremos casts

## Testing
- `npm run build` *(fails: Cannot find module 'react')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68562d2cb52c83318c4a35be5cfd5b57