### PR TITLE
Add interfaces and remove any

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,15 @@ import HomePage from "./components/HomePage";
 import PoliticaPrivacidad from "./components/PoliticaPrivacidad";
 import TerminosCondiciones from "./components/TerminosCondiciones";
 import credencialesBase from "./config/credentials.json";
-import { CredencialEmpresa } from "./types";
+import {
+  CredencialEmpresa,
+  FichaDatosGenerales as FichaDatos,
+  SurveyResponses,
+  IntralaboralResultado,
+  ExtralaboralResultado,
+  EstresResultado,
+  GlobalResultado,
+} from "./types";
 import {
   bloquesFormaA,
   bloquesFormaB,
@@ -45,26 +53,28 @@ export default function App() {
   >("inicio");
 
   const [formType, setFormType] = useState<"A" | "B" | null>(null);
-  const [ficha, setFicha] = useState<any>(null);
+  const [ficha, setFicha] = useState<FichaDatos | null>(null);
 
   const [empresasIniciales, setEmpresasIniciales] = useState<string[]>(() => {
     const guardadas = JSON.parse(localStorage.getItem("empresasCogent") || "[]");
     return guardadas.length ? guardadas : ["Sonria", "Aeropuerto El Dorado"];
   });
   const [credenciales, setCredenciales] = useState<(CredencialEmpresa & { rol: string })[]>(() => {
-    const extras = JSON.parse(localStorage.getItem("credencialesCogent") || "[]");
+    const extras: (CredencialEmpresa & { rol: string })[] = JSON.parse(
+      localStorage.getItem("credencialesCogent") || "[]"
+    );
     return [...credencialesBase, ...extras];
   });
 
   // Para guardar todas las respuestas por sección
-  const [respuestas, setRespuestas] = useState<any>({});
+  const [respuestas, setRespuestas] = useState<SurveyResponses>({});
   // Para guardar los resultados de cada test
-  const [resultadoEstres, setResultadoEstres] = useState<any>(null);
-  const [resultadoExtralaboral, setResultadoExtralaboral] = useState<any>(null);
-  const [resultadoFormaA, setResultadoFormaA] = useState<any>(null);
-  const [resultadoFormaB, setResultadoFormaB] = useState<any>(null);
-  const [resultadoGlobalAExtra, setResultadoGlobalAExtra] = useState<any>(null);
-  const [resultadoGlobalBExtra, setResultadoGlobalBExtra] = useState<any>(null);
+  const [resultadoEstres, setResultadoEstres] = useState<EstresResultado | null>(null);
+  const [resultadoExtralaboral, setResultadoExtralaboral] = useState<ExtralaboralResultado | null>(null);
+  const [resultadoFormaA, setResultadoFormaA] = useState<IntralaboralResultado | null>(null);
+  const [resultadoFormaB, setResultadoFormaB] = useState<IntralaboralResultado | null>(null);
+  const [resultadoGlobalAExtra, setResultadoGlobalAExtra] = useState<GlobalResultado | null>(null);
+  const [resultadoGlobalBExtra, setResultadoGlobalBExtra] = useState<GlobalResultado | null>(null);
 
   // Manejo de login (muy básico)
   const [rol, setRol] = useState<RolUsuario>("ninguno");
@@ -86,8 +96,10 @@ export default function App() {
   };
 
   const eliminarEmpresa = (usuario: string) => {
-    const extras = JSON.parse(localStorage.getItem("credencialesCogent") || "[]");
-    const filtradas = extras.filter((c: any) => c.usuario !== usuario);
+    const extras: (CredencialEmpresa & { rol: string })[] = JSON.parse(
+      localStorage.getItem("credencialesCogent") || "[]"
+    );
+    const filtradas = extras.filter((c) => c.usuario !== usuario);
     localStorage.setItem("credencialesCogent", JSON.stringify(filtradas));
     setCredenciales([...credencialesBase, ...filtradas]);
   };
@@ -98,8 +110,10 @@ export default function App() {
     usuario: string,
     password: string
   ) => {
-    const extras = JSON.parse(localStorage.getItem("credencialesCogent") || "[]");
-    const nuevas = extras.map((c: any) =>
+    const extras: (CredencialEmpresa & { rol: string })[] = JSON.parse(
+      localStorage.getItem("credencialesCogent") || "[]"
+    );
+    const nuevas = extras.map((c) =>
       c.usuario === originalUsuario
         ? { usuario, password, rol: "dueno", empresa: nombre }
         : c
@@ -107,7 +121,7 @@ export default function App() {
     localStorage.setItem("credencialesCogent", JSON.stringify(nuevas));
     setCredenciales([...credencialesBase, ...nuevas]);
     const empresasGuardadas = JSON.parse(localStorage.getItem("empresasCogent") || "[]");
-    const anterior = extras.find((c: any) => c.usuario === originalUsuario)?.empresa;
+    const anterior = extras.find((c) => c.usuario === originalUsuario)?.empresa;
     let nuevasEmp = empresasGuardadas.filter((e: string) => e !== anterior);
     if (!nuevasEmp.includes(nombre)) {
       nuevasEmp.push(nombre);
@@ -253,7 +267,7 @@ export default function App() {
               { length: formType === "A" ? preguntasA.length : preguntasB.length },
               (_, i) => respuestasBloques[i] ?? ""
             );
-            setRespuestas((prev: any) => ({ ...prev, bloques: ordered }));
+            setRespuestas((prev) => ({ ...prev, bloques: ordered }));
             setStep("extralaboral");
           }}
         />
@@ -272,7 +286,7 @@ export default function App() {
               formType as "A" | "B"
             );
             setResultadoExtralaboral(resultado);
-            setRespuestas((prev: any) => ({
+            setRespuestas((prev) => ({
               ...prev,
               extralaboral: ordered,
               resultadoExtralaboral: resultado
@@ -295,7 +309,7 @@ export default function App() {
               formType as "A" | "B"
             );
             setResultadoEstres(resultado);
-            setRespuestas((prev: any) => ({
+            setRespuestas((prev) => ({
               ...prev,
               estres: ordered,
               resultadoEstres: resultado

--- a/src/components/BloquesDePreguntas.tsx
+++ b/src/components/BloquesDePreguntas.tsx
@@ -17,12 +17,12 @@ type Pregunta = {
 type Props = {
   bloques: Bloque[];
   preguntas: Pregunta[];
-  onFinish: (respuestas: any) => void;
+  onFinish: (respuestas: Record<number, string>) => void;
 };
 
 export default function BloquesDePreguntas({ bloques, preguntas, onFinish }: Props) {
   const [bloqueActual, setBloqueActual] = useState(0);
-  const [respuestas, setRespuestas] = useState<any>({});
+  const [respuestas, setRespuestas] = useState<Record<number, string>>({});
 
   const debeMostrar = (bloque: Bloque) => {
     if (!bloque.condicional) return true;
@@ -51,8 +51,8 @@ export default function BloquesDePreguntas({ bloques, preguntas, onFinish }: Pro
     );
 
   // Cambiar la respuesta
-  const handleChange = (idx: number, valor: any) => {
-    setRespuestas((prev: any) => ({ ...prev, [idx]: valor }));
+  const handleChange = (idx: number, valor: string) => {
+    setRespuestas((prev) => ({ ...prev, [idx]: valor }));
   };
 
   // Botón siguiente: validación y control del flujo

--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -13,7 +13,7 @@ import TablaDimensiones from "@/components/TablaDimensiones";
 import GraficaBarra from "@/components/GraficaBarra";
 import GraficaBarraSimple from "@/components/GraficaBarraSimple";
 import AdminEmpresas from "@/components/AdminEmpresas";
-import { CredencialEmpresa, ResultRow } from "@/types";
+import { CredencialEmpresa, ResultRow, CategoriaConteo } from "@/types";
 import GeneralResultsTabs from "@/components/dashboard/GeneralResultsTabs";
 import FormaTabs from "@/components/dashboard/FormaTabs";
 import LogoCogent from "/logo_forma.png";
@@ -244,7 +244,9 @@ export default function DashboardResultados({
               const form = d.tipo;
               let seccion = d.resultadoExtralaboral?.dimensiones?.[nombre];
               if (Array.isArray(d.resultadoExtralaboral?.dimensiones)) {
-                seccion = d.resultadoExtralaboral.dimensiones.find((x: any) => x.nombre === nombre);
+                seccion = d.resultadoExtralaboral.dimensiones.find(
+                  (x) => x.nombre === nombre
+                );
               }
               const puntaje = seccion?.transformado ?? seccion?.puntajeTransformado;
               if (typeof puntaje !== "number") return undefined;
@@ -289,7 +291,7 @@ export default function DashboardResultados({
         .map((d) => {
           let seccion = d[key]?.[subkey]?.[nombre];
           if (Array.isArray(d[key]?.[subkey])) {
-            const item = d[key][subkey].find((x: any) => x.nombre === nombre);
+            const item = d[key][subkey].find((x) => x.nombre === nombre);
             seccion = item;
           }
           if (typeof seccion === "object") {
@@ -386,11 +388,11 @@ export default function DashboardResultados({
     }));
   }
 
-  const fichaConteosA: Record<string, any[]> = {};
-  const fichaConteosB: Record<string, any[]> = {};
-  const fichaConteosExtra: Record<string, any[]> = {};
-  const fichaConteosEstres: Record<string, any[]> = {};
-  const fichaConteosGlobal: Record<string, any[]> = {};
+  const fichaConteosA: Record<string, CategoriaConteo[]> = {};
+  const fichaConteosB: Record<string, CategoriaConteo[]> = {};
+  const fichaConteosExtra: Record<string, CategoriaConteo[]> = {};
+  const fichaConteosEstres: Record<string, CategoriaConteo[]> = {};
+  const fichaConteosGlobal: Record<string, CategoriaConteo[]> = {};
 
   categoriasFicha.forEach((cat) => {
     fichaConteosA[cat.key] = conteosPorFicha(datosA, cat.key);
@@ -427,7 +429,7 @@ export default function DashboardResultados({
       nivelesEstresMap[n] = i;
     });
 
-    const row: Record<string, any> = {};
+    const row: Record<string, string | number | undefined> = {};
     allHeaders.forEach((h) => {
       const valores = datosInforme
         .map((f) => f[h])
@@ -463,7 +465,7 @@ export default function DashboardResultados({
 
   // ---- Exportar a Excel ----
   const handleExportar = () => {
-    let datosExportar: any[] = [];
+    let datosExportar: ResultRow[] = [];
     if (tab === "general") datosExportar = datosMostrados;
     else if (tab === "formaA") datosExportar = datosA;
     else if (tab === "formaB") datosExportar = datosB;

--- a/src/components/FichaDatosGenerales.tsx
+++ b/src/components/FichaDatosGenerales.tsx
@@ -1,8 +1,9 @@
 import React, { useState } from "react";
+import { FichaDatosGenerales as FichaDatos } from "@/types";
 
 type Props = {
   empresasIniciales: string[];
-  onGuardar: (datos: any) => void;
+  onGuardar: (datos: FichaDatos) => void;
 };
 
 const estadosCiviles = [
@@ -38,7 +39,7 @@ export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Pr
   const empresas = empresasIniciales;
   const [empresa, setEmpresa] = useState("");
 
-  const [datos, setDatos] = useState<any>({
+  const [datos, setDatos] = useState<FichaDatos>({
     fecha: "",
     nombre: "",
     cedula: "",

--- a/src/components/GraficaBarraCategorias.tsx
+++ b/src/components/GraficaBarraCategorias.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { CategoriaConteo } from "@/types";
 import {
   BarChart,
   Bar,
@@ -28,7 +29,7 @@ export default function GraficaBarraCategorias({
   titulo,
   chartType,
 }: {
-  datos: any[];
+  datos: CategoriaConteo[];
   titulo: string;
   chartType: "bar" | "histogram" | "pie";
 }) {

--- a/src/components/TablaDimensiones.tsx
+++ b/src/components/TablaDimensiones.tsx
@@ -19,14 +19,14 @@ export default function TablaDimensiones({ datos, dimensiones, keyResultado }: {
         .map((d) => {
           let seccion = d[keyResultado]?.dimensiones?.[dim];
           if (Array.isArray(d[keyResultado]?.dimensiones)) {
-            seccion = d[keyResultado].dimensiones.find((x: any) => x.nombre === dim);
+            seccion = d[keyResultado].dimensiones.find((x) => x.nombre === dim);
           }
           if (typeof seccion === "object") {
             return seccion.transformado ?? seccion.puntajeTransformado;
           }
           return d[keyResultado]?.puntajesDimension?.[dim];
         })
-        .filter((v: any) => typeof v === "number");
+        .filter((v) => typeof v === "number");
       const prom = valores.length ? valores.reduce((a, b) => a + b, 0) / valores.length : 0;
       const promedio = Math.round(prom * 10) / 10;
       const baremos =
@@ -34,7 +34,7 @@ export default function TablaDimensiones({ datos, dimensiones, keyResultado }: {
           ? baremosFormaA.dimensiones[dim] || []
           : baremosFormaB.dimension[dim] || [];
       const nivel =
-        baremos.find((b: any) => promedio >= b.min && promedio <= b.max)?.nivel || "No clasificado";
+        baremos.find((b) => promedio >= b.min && promedio <= b.max)?.nivel || "No clasificado";
       return {
         promedio,
         nivel: nivel === "Sin riesgo" ? "Riesgo muy bajo" : nivel,
@@ -66,7 +66,7 @@ export default function TablaDimensiones({ datos, dimensiones, keyResultado }: {
               {dimensiones.map((dim, idx) => {
                 let seccion = d[keyResultado]?.dimensiones?.[dim];
                 if (Array.isArray(d[keyResultado]?.dimensiones)) {
-                  const item = d[keyResultado].dimensiones.find((x: any) => x.nombre === dim);
+                  const item = d[keyResultado].dimensiones.find((x) => x.nombre === dim);
                   seccion = item;
                 }
                 const valor =

--- a/src/components/TablaDominios.tsx
+++ b/src/components/TablaDominios.tsx
@@ -19,14 +19,14 @@ export default function TablaDominios({ datos, dominios, keyResultado }: { datos
         .map((d) => {
           let seccion = d[keyResultado]?.dominios?.[dom];
           if (Array.isArray(d[keyResultado]?.dominios)) {
-            seccion = d[keyResultado].dominios.find((x: any) => x.nombre === dom);
+            seccion = d[keyResultado].dominios.find((x) => x.nombre === dom);
           }
           if (typeof seccion === "object") {
             return seccion.transformado ?? seccion.puntajeTransformado;
           }
           return d[keyResultado]?.puntajesDominio?.[dom];
         })
-        .filter((v: any) => typeof v === "number");
+        .filter((v) => typeof v === "number");
       const prom = valores.length ? valores.reduce((a, b) => a + b, 0) / valores.length : 0;
       const promedio = Math.round(prom * 10) / 10;
       const baremos =
@@ -34,7 +34,7 @@ export default function TablaDominios({ datos, dominios, keyResultado }: { datos
           ? baremosFormaA.dominios[dom] || []
           : baremosFormaB.dominio[dom] || [];
       const nivel =
-        baremos.find((b: any) => promedio >= b.min && promedio <= b.max)?.nivel || "No clasificado";
+        baremos.find((b) => promedio >= b.min && promedio <= b.max)?.nivel || "No clasificado";
       return {
         promedio,
         nivel: nivel === "Sin riesgo" ? "Riesgo muy bajo" : nivel,
@@ -66,7 +66,7 @@ export default function TablaDominios({ datos, dominios, keyResultado }: { datos
               {dominios.map((dom, idx) => {
                 let seccion = d[keyResultado]?.dominios?.[dom];
                 if (Array.isArray(d[keyResultado]?.dominios)) {
-                  const item = d[keyResultado].dominios.find((x: any) => x.nombre === dom);
+                  const item = d[keyResultado].dominios.find((x) => x.nombre === dom);
                   seccion = item;
                 }
                 const valor =

--- a/src/components/dashboard/FichaTecnicaTabs.tsx
+++ b/src/components/dashboard/FichaTecnicaTabs.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import GraficaBarraCategorias from "../GraficaBarraCategorias";
+import { CategoriaConteo } from "@/types";
 
 
 export type CategoriaFicha = { key: string; label: string };
@@ -16,7 +17,7 @@ export default function FichaTecnicaTabs({
   categorias: readonly CategoriaFicha[];
   categoria: string;
   onChange: (value: string) => void;
-  conteos: Record<string, any[]>;
+  conteos: Record<string, CategoriaConteo[]>;
   chartType: "bar" | "histogram" | "pie";
   tabClass: string;
 }) {

--- a/src/components/dashboard/FormaTabs.tsx
+++ b/src/components/dashboard/FormaTabs.tsx
@@ -5,7 +5,7 @@ import GraficaBarra from "@/components/GraficaBarra";
 import TablaIndividual from "@/components/TablaIndividual";
 import TablaDominios from "@/components/TablaDominios";
 import TablaDimensiones from "@/components/TablaDimensiones";
-import { ResultRow } from "@/types";
+import { ResultRow, NivelResumenCantidad, PromedioDato } from "@/types";
 
 export default function FormaTabs({
   value,
@@ -25,9 +25,9 @@ export default function FormaTabs({
   value: string;
   onChange: (v: string) => void;
   datos: ResultRow[];
-  resumen: any[];
-  promediosDominios: any[];
-  promediosDimensiones: any[];
+  resumen: NivelResumenCantidad[];
+  promediosDominios: PromedioDato[];
+  promediosDimensiones: PromedioDato[];
   dominios: string[];
   dimensiones: string[];
   chartType: "bar" | "histogram" | "pie";

--- a/src/components/dashboard/GeneralResultsTabs.tsx
+++ b/src/components/dashboard/GeneralResultsTabs.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import GraficaBarraSimple from "@/components/GraficaBarraSimple";
 import FichaTecnicaTabs, { CategoriaFicha } from "./FichaTecnicaTabs";
-import { NivelResumen } from "@/types";
+import { NivelResumen, ResultRow, CategoriaConteo, NivelResumenCantidad } from "@/types";
 
 export default function GeneralResultsTabs({
   value,
@@ -26,18 +26,18 @@ export default function GeneralResultsTabs({
   onChange: (v: string) => void;
   tabClass: string;
   chartType: "bar" | "histogram" | "pie";
-  datosA: any[];
-  datosB: any[];
-  datosExtra: any[];
-  datosEstres: any[];
-  resumenA: (NivelResumen & { cantidad: number })[];
-  resumenB: (NivelResumen & { cantidad: number })[];
-  resumenExtra: (NivelResumen & { cantidad: number })[];
-  resumenEstres: (NivelResumen & { cantidad: number })[];
+  datosA: ResultRow[];
+  datosB: ResultRow[];
+  datosExtra: ResultRow[];
+  datosEstres: ResultRow[];
+  resumenA: NivelResumenCantidad[];
+  resumenB: NivelResumenCantidad[];
+  resumenExtra: NivelResumenCantidad[];
+  resumenEstres: NivelResumenCantidad[];
   categoriaFicha: string;
   onCategoriaChange: (v: string) => void;
   categoriasFicha: readonly CategoriaFicha[];
-  fichaConteos: Record<string, any[]>;
+  fichaConteos: Record<string, CategoriaConteo[]>;
 }) {
   return (
     <Tabs value={value} onValueChange={onChange} className="w-full">

--- a/src/types/NivelResumen.ts
+++ b/src/types/NivelResumen.ts
@@ -3,3 +3,19 @@ export interface NivelResumen {
   indice: number;
   nivel: string;
 }
+
+export interface NivelResumenCantidad extends NivelResumen {
+  cantidad: number;
+}
+
+export interface PromedioDato {
+  nombre: string;
+  promedio: number;
+  nivel: string;
+  indice: number;
+}
+
+export interface CategoriaConteo {
+  nombre: string;
+  cantidad: number;
+}

--- a/src/types/Resultados.ts
+++ b/src/types/Resultados.ts
@@ -43,6 +43,14 @@ export interface EstresResultado {
   nivel: string;
 }
 
+export interface SurveyResponses {
+  bloques?: string[];
+  extralaboral?: string[];
+  estres?: string[];
+  resultadoExtralaboral?: ExtralaboralResultado;
+  resultadoEstres?: EstresResultado;
+}
+
 export interface FichaDatosGenerales {
   fecha: string;
   nombre: string;
@@ -74,7 +82,7 @@ export interface FichaDatosGenerales {
 
 export interface ResultRow {
   ficha?: FichaDatosGenerales;
-  respuestas?: any;
+  respuestas?: SurveyResponses;
   resultadoFormaA?: IntralaboralResultado;
   resultadoFormaB?: IntralaboralResultado;
   resultadoExtralaboral?: ExtralaboralResultado;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,4 @@
 export * from './CredencialEmpresa';
 export * from './Resultados';
+export * from './NivelResumen';
 

--- a/src/utils/calcularFormaA.ts
+++ b/src/utils/calcularFormaA.ts
@@ -1,14 +1,10 @@
 import { esquemaFormaA } from "../data/esquemaFormaA";
 import { factoresFormaA } from "../data/factoresFormaA";
 import { baremosFormaA } from "../data/baremosFormaA";
+import { Baremo } from "@/types";
 
 type Respuestas = string[];
 
-interface Baremo {
-  nivel: string;
-  min: number;
-  max: number;
-}
 
 // Preguntas con esquema directo e inverso
 const directas = new Set(

--- a/src/utils/calcularFormaB.ts
+++ b/src/utils/calcularFormaB.ts
@@ -1,12 +1,8 @@
 import { esquemaFormaB } from "../data/esquemaFormaB";
 import { factoresFormaB } from "../data/factoresFormaB";
 import { baremosFormaB } from "../data/baremosFormaB";
+import { Baremo } from "@/types";
 
-interface Baremo {
-  nivel: string;
-  min: number;
-  max: number;
-}
 
 // Mapeo para esquema de puntaje directo e inverso
 const directas = new Set(esquemaFormaB.filter(q => q.esquema === "directo").map(q => q.numero));

--- a/src/utils/calcularGlobalA.ts
+++ b/src/utils/calcularGlobalA.ts
@@ -1,11 +1,7 @@
 // src/utils/calcularGlobalA.ts
 
 // Baremos para el global A + extralaboral
-interface Baremo {
-  nivel: string;
-  min: number;
-  max: number;
-}
+import { Baremo } from "@/types";
 
 export const baremoGlobalAExtrala: Baremo[] = [
   { nivel: "Sin riesgo", min: 0.0, max: 18.8 },

--- a/src/utils/gatherResults.ts
+++ b/src/utils/gatherResults.ts
@@ -1,3 +1,13 @@
+import { ResultRow, DimensionResultado, IntralaboralResultado } from "@/types";
+
+type IntralaboralResultadoCompat = IntralaboralResultado & {
+  puntajeTransformadoTotal?: number;
+  puntajeTransformado?: number;
+  puntajeTotalTransformado?: number;
+  nivelTotal?: string;
+  nivel?: string;
+};
+
 export type FlatResult = Record<string, string | number | undefined>;
 
 interface ResultadoExtraDimension {
@@ -11,8 +21,9 @@ interface ResultadoExtraDimension {
  * Obtiene los resultados almacenados y los convierte en un arreglo
  * de objetos planos (una fila por empleado).
  */
+
 export function gatherFlatResults(): FlatResult[] {
-  const almacenados: any[] = JSON.parse(
+  const almacenados: ResultRow[] = JSON.parse(
     localStorage.getItem("resultadosCogent") || "[]"
   );
 
@@ -31,39 +42,40 @@ export function gatherFlatResults(): FlatResult[] {
       fila["Nivel Forma A"] = d.resultadoFormaA.total?.nivel ?? "";
       const domA = d.resultadoFormaA.dominios || {};
       Object.keys(domA).forEach((k) => {
-        const v = domA[k];
+        const v = domA[k] as DimensionResultado & { puntajeTransformado?: number };
         fila[`A ${k}`] = v.transformado ?? v.puntajeTransformado ?? "";
         fila[`Nivel A ${k}`] = v.nivel ?? "";
       });
       const dimA = d.resultadoFormaA.dimensiones || {};
       Object.keys(dimA).forEach((k) => {
-        const v = dimA[k];
+        const v = dimA[k] as DimensionResultado & { puntajeTransformado?: number };
         fila[`A ${k}`] = v.transformado ?? v.puntajeTransformado ?? "";
         fila[`Nivel A ${k}`] = v.nivel ?? "";
       });
     }
 
     if (d.resultadoFormaB) {
+      const resB = d.resultadoFormaB as IntralaboralResultadoCompat;
       fila["Puntaje Forma B"] =
-        d.resultadoFormaB.total?.transformado ??
-        d.resultadoFormaB.puntajeTransformadoTotal ??
-        d.resultadoFormaB.puntajeTransformado ??
-        d.resultadoFormaB.puntajeTotalTransformado ??
+        resB.total?.transformado ??
+        resB.puntajeTransformadoTotal ??
+        resB.puntajeTransformado ??
+        resB.puntajeTotalTransformado ??
         "";
       fila["Nivel Forma B"] =
-        d.resultadoFormaB.total?.nivel ??
-        d.resultadoFormaB.nivelTotal ??
-        d.resultadoFormaB.nivel ??
+        resB.total?.nivel ??
+        resB.nivelTotal ??
+        resB.nivel ??
         "";
-      const domB = d.resultadoFormaB.dominios || {};
+      const domB = resB.dominios || {};
       Object.keys(domB).forEach((k) => {
-        const v = domB[k];
+        const v = domB[k] as DimensionResultado & { puntajeTransformado?: number };
         fila[`B ${k}`] = v.transformado ?? v.puntajeTransformado ?? "";
         fila[`Nivel B ${k}`] = v.nivel ?? "";
       });
-      const dimB = d.resultadoFormaB.dimensiones || {};
+      const dimB = resB.dimensiones || {};
       Object.keys(dimB).forEach((k) => {
-        const v = dimB[k];
+        const v = dimB[k] as DimensionResultado & { puntajeTransformado?: number };
         fila[`B ${k}`] = v.transformado ?? v.puntajeTransformado ?? "";
         fila[`Nivel B ${k}`] = v.nivel ?? "";
       });


### PR DESCRIPTION
## Summary
- define reusable interfaces for summaries, baremos, survey responses, etc
- apply typed props and state in components
- remove `any` from table helpers and dashboard logic
- standardize utils to use interfaces

## Testing
- `npm run build` *(fails: cannot access network and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6856301e00548331b38a5f032d99d620