### PR TITLE
Fix type definitions and indexing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -138,7 +138,7 @@ export default function App() {
       let resultadoGlobal = null;
       if (formType === "A" && respuestas.bloques) {
         const arr = Array.from({ length: preguntasA.length }, (_, i) =>
-          respuestas.bloques[i] ?? ""
+          respuestas.bloques?.[i] ?? ""
         );
         resultadoForma = calcularFormaA(arr);
         setResultadoFormaA(resultadoForma);
@@ -151,7 +151,7 @@ export default function App() {
         }
       } else if (formType === "B" && respuestas.bloques) {
         const arr = Array.from({ length: preguntasB.length }, (_, i) =>
-          respuestas.bloques[i] ?? ""
+          respuestas.bloques?.[i] ?? ""
         );
         resultadoForma = calcularFormaB(arr);
         setResultadoFormaB(resultadoForma);

--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -193,10 +193,12 @@ export default function DashboardResultados({
 
   // ---- Resúmenes para gráficos ----
   const resumenNivel = (datos: ResultRow[], key: string, niveles: string[]) =>
-    niveles.map((nivel) => ({
+    niveles.map((nivel, idx) => ({
+      nombre: nivel,
       nivel,
+      indice: idx,
       cantidad: datos.filter((d) => {
-        const r = d[key];
+        const r = (d as any)[key];
         const nivelRes =
           r?.total?.nivel ?? r?.nivelTotal ?? r?.nivelGlobal ?? r?.nivel;
         return (
@@ -289,9 +291,10 @@ export default function DashboardResultados({
     campos.forEach((nombre) => {
       const valores = datos
         .map((d) => {
-          let seccion = d[key]?.[subkey]?.[nombre];
-          if (Array.isArray(d[key]?.[subkey])) {
-            const item = d[key][subkey].find((x) => x.nombre === nombre);
+          const res = (d as any)[key];
+          let seccion = res?.[subkey]?.[nombre];
+          if (Array.isArray(res?.[subkey])) {
+            const item = res[subkey].find((x: any) => x.nombre === nombre);
             seccion = item;
           }
           if (typeof seccion === "object") {
@@ -299,10 +302,10 @@ export default function DashboardResultados({
           }
           // Compatibilidad con estructura de Forma B (puntajesDimension/puntajesDominio)
           if (subkey === "dimensiones") {
-            return d[key]?.puntajesDimension?.[nombre];
+            return res?.puntajesDimension?.[nombre];
           }
           if (subkey === "dominios") {
-            return d[key]?.puntajesDominio?.[nombre];
+            return res?.puntajesDominio?.[nombre];
           }
           return undefined;
         })
@@ -381,10 +384,12 @@ export default function DashboardResultados({
         }).length,
       }));
     }
-    const grupos = Array.from(new Set(datos.map((d) => d.ficha?.[keyFicha] ?? "Sin dato")));
+    const grupos = Array.from(
+      new Set(datos.map((d) => (d.ficha as any)?.[keyFicha] ?? "Sin dato"))
+    );
     return grupos.map((valor) => ({
       nombre: valor,
-      cantidad: datos.filter((d) => (d.ficha?.[keyFicha] ?? "Sin dato") === valor).length,
+      cantidad: datos.filter((d) => ((d.ficha as any)?.[keyFicha] ?? "Sin dato") === valor).length,
     }));
   }
 
@@ -465,7 +470,7 @@ export default function DashboardResultados({
 
   // ---- Exportar a Excel ----
   const handleExportar = () => {
-    let datosExportar: ResultRow[] = [];
+    let datosExportar: (ResultRow | FlatResult)[] = [];
     if (tab === "general") datosExportar = datosMostrados;
     else if (tab === "formaA") datosExportar = datosA;
     else if (tab === "formaB") datosExportar = datosB;

--- a/src/components/TablaDimensiones.tsx
+++ b/src/components/TablaDimensiones.tsx
@@ -17,14 +17,15 @@ export default function TablaDimensiones({ datos, dimensiones, keyResultado }: {
     return dimensiones.map((dim) => {
       const valores = datos
         .map((d) => {
-          let seccion = d[keyResultado]?.dimensiones?.[dim];
-          if (Array.isArray(d[keyResultado]?.dimensiones)) {
-            seccion = d[keyResultado].dimensiones.find((x) => x.nombre === dim);
+          const res = (d as any)[keyResultado];
+          let seccion = res?.dimensiones?.[dim];
+          if (Array.isArray(res?.dimensiones)) {
+            seccion = res.dimensiones.find((x: any) => x.nombre === dim);
           }
           if (typeof seccion === "object") {
             return seccion.transformado ?? seccion.puntajeTransformado;
           }
-          return d[keyResultado]?.puntajesDimension?.[dim];
+          return res?.puntajesDimension?.[dim];
         })
         .filter((v) => typeof v === "number");
       const prom = valores.length ? valores.reduce((a, b) => a + b, 0) / valores.length : 0;
@@ -64,15 +65,16 @@ export default function TablaDimensiones({ datos, dimensiones, keyResultado }: {
               <td>{d.ficha?.empresa}</td>
               <td>{d.ficha?.nombre}</td>
               {dimensiones.map((dim, idx) => {
-                let seccion = d[keyResultado]?.dimensiones?.[dim];
-                if (Array.isArray(d[keyResultado]?.dimensiones)) {
-                  const item = d[keyResultado].dimensiones.find((x) => x.nombre === dim);
+                const res = (d as any)[keyResultado];
+                let seccion = res?.dimensiones?.[dim];
+                if (Array.isArray(res?.dimensiones)) {
+                  const item = res.dimensiones.find((x: any) => x.nombre === dim);
                   seccion = item;
                 }
                 const valor =
                   typeof seccion === "object"
                     ? seccion.transformado ?? seccion.puntajeTransformado
-                    : d[keyResultado]?.puntajesDimension?.[dim];
+                    : res?.puntajesDimension?.[dim];
                 return <td key={idx}>{valor ?? ""}</td>;
               })}
             </tr>

--- a/src/components/TablaDominios.tsx
+++ b/src/components/TablaDominios.tsx
@@ -17,14 +17,15 @@ export default function TablaDominios({ datos, dominios, keyResultado }: { datos
     return dominios.map((dom) => {
       const valores = datos
         .map((d) => {
-          let seccion = d[keyResultado]?.dominios?.[dom];
-          if (Array.isArray(d[keyResultado]?.dominios)) {
-            seccion = d[keyResultado].dominios.find((x) => x.nombre === dom);
+          const res = (d as any)[keyResultado];
+          let seccion = res?.dominios?.[dom];
+          if (Array.isArray(res?.dominios)) {
+            seccion = res.dominios.find((x: any) => x.nombre === dom);
           }
           if (typeof seccion === "object") {
             return seccion.transformado ?? seccion.puntajeTransformado;
           }
-          return d[keyResultado]?.puntajesDominio?.[dom];
+          return res?.puntajesDominio?.[dom];
         })
         .filter((v) => typeof v === "number");
       const prom = valores.length ? valores.reduce((a, b) => a + b, 0) / valores.length : 0;
@@ -64,15 +65,16 @@ export default function TablaDominios({ datos, dominios, keyResultado }: { datos
               <td>{d.ficha?.empresa}</td>
               <td>{d.ficha?.nombre}</td>
               {dominios.map((dom, idx) => {
-                let seccion = d[keyResultado]?.dominios?.[dom];
-                if (Array.isArray(d[keyResultado]?.dominios)) {
-                  const item = d[keyResultado].dominios.find((x) => x.nombre === dom);
+                const res = (d as any)[keyResultado];
+                let seccion = res?.dominios?.[dom];
+                if (Array.isArray(res?.dominios)) {
+                  const item = res.dominios.find((x: any) => x.nombre === dom);
                   seccion = item;
                 }
                 const valor =
                   typeof seccion === "object"
                     ? seccion.transformado ?? seccion.puntajeTransformado
-                    : d[keyResultado]?.puntajesDominio?.[dom];
+                    : res?.puntajesDominio?.[dom];
                 return <td key={idx}>{valor ?? ""}</td>;
               })}
             </tr>

--- a/src/types/CredencialEmpresa.ts
+++ b/src/types/CredencialEmpresa.ts
@@ -1,5 +1,5 @@
 export interface CredencialEmpresa {
   usuario: string;
   password: string;
-  empresa: string;
+  empresa?: string;
 }

--- a/src/types/Resultados.ts
+++ b/src/types/Resultados.ts
@@ -11,9 +11,16 @@ export interface DimensionResultado {
 }
 
 export interface IntralaboralResultado {
-  dimensiones: Record<string, DimensionResultado>;
-  dominios: Record<string, DimensionResultado>;
-  total: DimensionResultado & { suma: number };
+  dimensiones?: Record<string, DimensionResultado>;
+  dominios?: Record<string, DimensionResultado>;
+  total?: (DimensionResultado & { suma?: number }) | null;
+  valido?: boolean;
+  error?: string;
+  puntajeTransformadoTotal?: number;
+  puntajeTransformado?: number;
+  puntajeTotalTransformado?: number;
+  nivelTotal?: string;
+  nivel?: string;
 }
 
 export interface ExtralaboralDimensionResultado {
@@ -25,10 +32,11 @@ export interface ExtralaboralDimensionResultado {
 
 export interface ExtralaboralResultado {
   valido: boolean;
-  dimensiones: ExtralaboralDimensionResultado[];
-  puntajeBrutoTotal: number;
-  puntajeTransformadoTotal: number;
-  nivelGlobal: string;
+  error?: string;
+  dimensiones?: ExtralaboralDimensionResultado[];
+  puntajeBrutoTotal?: number;
+  puntajeTransformadoTotal?: number;
+  nivelGlobal?: string;
 }
 
 export interface GlobalResultado {
@@ -38,9 +46,10 @@ export interface GlobalResultado {
 
 export interface EstresResultado {
   valido: boolean;
-  puntajeBruto: number;
-  puntajeTransformado: number;
-  nivel: string;
+  error?: string;
+  puntajeBruto?: number;
+  puntajeTransformado?: number;
+  nivel?: string;
 }
 
 export interface SurveyResponses {


### PR DESCRIPTION
## Summary
- relax `CredencialEmpresa` to allow optional `empresa`
- expand result interfaces with optional fields
- fix summaries and dynamic key indexing in dashboard
- cast dynamic sections in tables
- guard against undefined responses

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_6856d8ff66348331b41e31eb66fb9271