### PR TITLE
Fix prop and undefined types

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -145,7 +145,7 @@ export default function App() {
         if (resultadoExtralaboral) {
           resultadoGlobal = calcularGlobalAExtrala(
             resultadoForma?.total?.suma ?? 0,
-            resultadoExtralaboral.puntajeBrutoTotal
+            resultadoExtralaboral.puntajeBrutoTotal ?? 0
           );
           setResultadoGlobalAExtra(resultadoGlobal);
         }
@@ -158,7 +158,7 @@ export default function App() {
         if (resultadoExtralaboral) {
           resultadoGlobal = calcularGlobalBExtrala(
             resultadoForma?.total?.suma ?? 0,
-            resultadoExtralaboral.puntajeBrutoTotal
+            resultadoExtralaboral.puntajeBrutoTotal ?? 0
           );
           setResultadoGlobalBExtra(resultadoGlobal);
         }

--- a/src/components/AdminEmpresas.tsx
+++ b/src/components/AdminEmpresas.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { CredencialEmpresa } from "@/types";
 
 export default function AdminEmpresas({
   credenciales,
@@ -6,7 +7,7 @@ export default function AdminEmpresas({
   onEliminar,
   onEditar
 }: {
-  credenciales: { usuario: string; password: string; empresa: string }[];
+  credenciales: CredencialEmpresa[];
   onAgregar: (nombre: string, usuario: string, password: string) => void;
   onEliminar: (usuario: string) => void;
   onEditar: (

--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useMemo, useRef } from "react";
 
 import * as XLSX from "xlsx";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
-import { gatherFlatResults } from "@/utils/gatherResults";
+import { gatherFlatResults, FlatResult } from "@/utils/gatherResults";
 import { exportElementToPDF } from "@/utils/pdfExport";
 import { dimensionesExtralaboral } from "@/data/esquemaExtralaboral";
 import { baremosFormaA } from "@/data/baremosFormaA";
@@ -244,7 +244,9 @@ export default function DashboardResultados({
           const indices = datos
             .map((d) => {
               const form = d.tipo;
-              let seccion = d.resultadoExtralaboral?.dimensiones?.[nombre];
+              let seccion = (d.resultadoExtralaboral as any)?.dimensiones?.[
+                nombre as any
+              ];
               if (Array.isArray(d.resultadoExtralaboral?.dimensiones)) {
                 seccion = d.resultadoExtralaboral.dimensiones.find(
                   (x) => x.nombre === nombre


### PR DESCRIPTION
## Summary
- import `FlatResult` type in dashboard
- allow `CredencialEmpresa` with optional company name in admin component
- guard against missing extralaboral score when computing global results
- handle extralaboral dimensions that are stored either as an array or an object

## Testing
- `npm run build` *(fails: Cannot find modules)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6856de2c6bc0833193116187ba6f81ba