### PR TITLE
Fix prop and undefined types

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -145,7 +145,7 @@ export default function App() {
         if (resultadoExtralaboral) {
           resultadoGlobal = calcularGlobalAExtrala(
             resultadoForma?.total?.suma ?? 0,
-            resultadoExtralaboral.puntajeBrutoTotal
+            resultadoExtralaboral.puntajeBrutoTotal ?? 0
           );
           setResultadoGlobalAExtra(resultadoGlobal);
         }
@@ -158,7 +158,7 @@ export default function App() {
         if (resultadoExtralaboral) {
           resultadoGlobal = calcularGlobalBExtrala(
             resultadoForma?.total?.suma ?? 0,
-            resultadoExtralaboral.puntajeBrutoTotal
+            resultadoExtralaboral.puntajeBrutoTotal ?? 0
           );
           setResultadoGlobalBExtra(resultadoGlobal);
         }

--- a/src/components/AdminEmpresas.tsx
+++ b/src/components/AdminEmpresas.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { CredencialEmpresa } from "@/types";
 
 export default function AdminEmpresas({
   credenciales,
@@ -6,7 +7,7 @@ export default function AdminEmpresas({
   onEliminar,
   onEditar
 }: {
-  credenciales: { usuario: string; password: string; empresa: string }[];
+  credenciales: CredencialEmpresa[];
   onAgregar: (nombre: string, usuario: string, password: string) => void;
   onEliminar: (usuario: string) => void;
   onEditar: (
@@ -43,7 +44,7 @@ export default function AdminEmpresas({
     if (!editUsuario.trim() || !editPassword.trim()) return;
     onEditar(
       credenciales[editIndex].usuario,
-      credenciales[editIndex].empresa,
+      credenciales[editIndex].empresa || "",
       editUsuario.trim(),
       editPassword.trim()
     );
@@ -135,7 +136,7 @@ export default function AdminEmpresas({
                         className="px-2 py-0.5 text-xs bg-yellow-400 rounded"
                         onClick={() => {
                           setEditIndex(idx);
-                          setEditNombre(c.empresa);
+                          setEditNombre(c.empresa || "");
                           setEditUsuario(c.usuario);
                           setEditPassword(c.password);
                         }}


### PR DESCRIPTION
## Summary
- import `FlatResult` type in dashboard
- allow `CredencialEmpresa` with optional company name in admin component
- guard against missing extralaboral score when computing global results
- handle extralaboral dimensions that are stored either as an array or an object
- default to empty string when extralaboral company name is missing
- cast row type when exporting to Excel

## Testing
- `npm run build` *(fails: Cannot find modules)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6856de2c6bc0833193116187ba6f81ba