### PR TITLE
Save survey data to Firestore

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ npm run lint
 - `public/` - Static assets served directly
 - `index.html` - Entry point for the application
 
+## Firebase storage
+
+Results are saved in a Firestore collection named `resultadosCogent`. Edit
+`src/firebaseConfig.ts` with your Firebase project details before deploying.
+
 ## Sample credentials
 
 Default demo accounts are defined in `src/config/credentials.json`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "recharts": "^2.15.3",
         "tailwind-merge": "^3.3.1",
         "tailwindcss-animate": "^1.0.7",
-        "xlsx": "^0.18.5"
+        "xlsx": "^0.18.5",
+        "firebase": "^10.12.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "recharts": "^2.15.3",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
-    "xlsx": "^0.18.5"
+    "xlsx": "^0.18.5",
+    "firebase": "^10.12.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,6 @@
 import { useState, useEffect } from "react";
+import { collection, addDoc } from "firebase/firestore";
+import { db } from "./firebaseConfig";
 import Consentimiento from "./components/Consentimiento";
 import FormSelector from "./components/FormSelector";
 import FichaDatosGenerales from "./components/FichaDatosGenerales";
@@ -132,10 +134,11 @@ export default function App() {
 
   // Cuando finaliza la encuesta (luego del bloque de estrés)
   useEffect(() => {
-    if (step === "final") {
-      // Calcula resultados por formulario
-      let resultadoForma = null;
-      let resultadoGlobal = null;
+    const guardar = async () => {
+      if (step === "final") {
+        // Calcula resultados por formulario
+        let resultadoForma = null;
+        let resultadoGlobal = null;
       if (formType === "A" && respuestas.bloques) {
         const arr = Array.from({ length: preguntasA.length }, (_, i) =>
           respuestas.bloques?.[i] ?? ""
@@ -164,23 +167,24 @@ export default function App() {
         }
       }
 
-      // Guarda todo lo que quieras conservar
-      const data = {
-        ficha,
-        respuestas,
-        resultadoFormaA: formType === "A" ? resultadoForma : undefined,
-        resultadoFormaB: formType === "B" ? resultadoForma : undefined,
-        resultadoGlobalAExtralaboral: formType === "A" ? resultadoGlobal : undefined,
-        resultadoGlobalBExtralaboral: formType === "B" ? resultadoGlobal : undefined,
-        resultadoEstres,
-        resultadoExtralaboral,
-        tipo: formType,
-        fecha: ficha?.fecha || new Date().toISOString()
-      };
-      // Guarda un array con push (no sobreescribe)
-      const prev = JSON.parse(localStorage.getItem("resultadosCogent") || "[]");
-      localStorage.setItem("resultadosCogent", JSON.stringify([...prev, data]));
-    }
+        // Guarda todo lo que quieras conservar
+        const data = {
+          ficha,
+          respuestas,
+          resultadoFormaA: formType === "A" ? resultadoForma : undefined,
+          resultadoFormaB: formType === "B" ? resultadoForma : undefined,
+          resultadoGlobalAExtralaboral: formType === "A" ? resultadoGlobal : undefined,
+          resultadoGlobalBExtralaboral: formType === "B" ? resultadoGlobal : undefined,
+          resultadoEstres,
+          resultadoExtralaboral,
+          tipo: formType,
+          fecha: ficha?.fecha || new Date().toISOString()
+        };
+        // Guarda en Firestore
+        await addDoc(collection(db, "resultadosCogent"), data);
+      }
+    };
+    guardar();
   }, [step, ficha, respuestas, resultadoEstres, resultadoExtralaboral, formType]);
 
   // Vista Home

--- a/src/utils/gatherResults.ts
+++ b/src/utils/gatherResults.ts
@@ -22,10 +22,7 @@ interface ResultadoExtraDimension {
  * de objetos planos (una fila por empleado).
  */
 
-export function gatherFlatResults(): FlatResult[] {
-  const almacenados: ResultRow[] = JSON.parse(
-    localStorage.getItem("resultadosCogent") || "[]"
-  );
+export function gatherFlatResults(almacenados: ResultRow[]): FlatResult[] {
 
   return almacenados.map((d, idx) => {
     const fila: FlatResult = {


### PR DESCRIPTION
## Summary
- store survey responses in Firebase Firestore instead of localStorage
- fetch and delete results from Firestore dashboard
- adjust gatherResults helper
- document Firestore usage in README
- add `firebase` dependency

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6856ee20fa048331a5859741c4a22947