### PR TITLE
Add error handling for Firestore CRUD

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -126,24 +126,38 @@ export default function App() {
     nombre: string,
     usuario: string,
     password: string
-  ) => {
-    const docRef = await addDoc(collection(db, "credencialesCogent"), {
-      usuario,
-      password,
-      rol: "dueno",
-      empresa: nombre,
-    });
-    setCredenciales((prev) => [
-      ...prev,
-      { id: docRef.id, usuario, password, rol: "dueno", empresa: nombre },
-    ]);
+  ): Promise<boolean> => {
+    try {
+      const docRef = await addDoc(collection(db, "credencialesCogent"), {
+        usuario,
+        password,
+        rol: "dueno",
+        empresa: nombre,
+      });
+      setCredenciales((prev) => [
+        ...prev,
+        { id: docRef.id, usuario, password, rol: "dueno", empresa: nombre },
+      ]);
+      return true;
+    } catch (err) {
+      console.error("Error al agregar empresa", err);
+      alert("No se pudo agregar la empresa");
+      return false;
+    }
   };
 
-  const eliminarEmpresa = async (usuario: string) => {
+  const eliminarEmpresa = async (usuario: string): Promise<boolean> => {
     const cred = credenciales.find((c) => c.usuario === usuario);
-    if (!cred?.id) return;
-    await deleteDoc(doc(db, "credencialesCogent", cred.id));
-    setCredenciales((prev) => prev.filter((c) => c.usuario !== usuario));
+    if (!cred?.id) return false;
+    try {
+      await deleteDoc(doc(db, "credencialesCogent", cred.id));
+      setCredenciales((prev) => prev.filter((c) => c.usuario !== usuario));
+      return true;
+    } catch (err) {
+      console.error("Error al eliminar empresa", err);
+      alert("No se pudo eliminar la empresa");
+      return false;
+    }
   };
 
   const editarEmpresa = async (
@@ -151,21 +165,28 @@ export default function App() {
     nombre: string,
     usuario: string,
     password: string
-  ) => {
+  ): Promise<boolean> => {
     const cred = credenciales.find((c) => c.usuario === originalUsuario);
-    if (!cred?.id) return;
-    await updateDoc(doc(db, "credencialesCogent", cred.id), {
-      usuario,
-      password,
-      empresa: nombre,
-    });
-    setCredenciales((prev) =>
-      prev.map((c) =>
-        c.usuario === originalUsuario
-          ? { ...c, usuario, password, empresa: nombre }
-          : c
-      )
-    );
+    if (!cred?.id) return false;
+    try {
+      await updateDoc(doc(db, "credencialesCogent", cred.id), {
+        usuario,
+        password,
+        empresa: nombre,
+      });
+      setCredenciales((prev) =>
+        prev.map((c) =>
+          c.usuario === originalUsuario
+            ? { ...c, usuario, password, empresa: nombre }
+            : c
+        )
+      );
+      return true;
+    } catch (err) {
+      console.error("Error al editar empresa", err);
+      alert("No se pudo editar la empresa");
+      return false;
+    }
   };
 
   // Cuando finaliza la encuesta (luego del bloque de estrés)
@@ -222,7 +243,12 @@ export default function App() {
         }
         // Limpia datos y guarda en Firestore
         const cleanData = removeUndefined(data);
-        await addDoc(collection(db, "resultadosCogent"), cleanData);
+        try {
+          await addDoc(collection(db, "resultadosCogent"), cleanData);
+        } catch (err) {
+          console.error("Error al guardar resultados", err);
+          alert("No se pudieron guardar los resultados");
+        }
       }
     };
     guardar();

--- a/src/components/AdminEmpresas.tsx
+++ b/src/components/AdminEmpresas.tsx
@@ -8,14 +8,14 @@ export default function AdminEmpresas({
   onEditar
 }: {
   credenciales: CredencialEmpresa[];
-  onAgregar: (nombre: string, usuario: string, password: string) => void;
-  onEliminar: (usuario: string) => void;
+  onAgregar: (nombre: string, usuario: string, password: string) => Promise<boolean>;
+  onEliminar: (usuario: string) => Promise<boolean>;
   onEditar: (
     originalUsuario: string,
     nombre: string,
     usuario: string,
     password: string
-  ) => void;
+  ) => Promise<boolean>;
 }) {
   const [nombre, setNombre] = useState("");
   const [usuario, setUsuario] = useState("");
@@ -25,12 +25,14 @@ export default function AdminEmpresas({
   const [editUsuario, setEditUsuario] = useState("");
   const [editPassword, setEditPassword] = useState("");
 
-  const handleAgregar = () => {
+  const handleAgregar = async () => {
     if (!nombre.trim() || !usuario.trim() || !password.trim()) return;
-    onAgregar(nombre.trim(), usuario.trim(), password.trim());
-    setNombre("");
-    setUsuario("");
-    setPassword("");
+    const ok = await onAgregar(nombre.trim(), usuario.trim(), password.trim());
+    if (ok) {
+      setNombre("");
+      setUsuario("");
+      setPassword("");
+    }
   };
 
   const startEdit = (idx: number) => {
@@ -39,18 +41,20 @@ export default function AdminEmpresas({
     setEditPassword("");
   };
 
-  const handleGuardarEdicion = () => {
+  const handleGuardarEdicion = async () => {
     if (editIndex === null) return;
     if (!editUsuario.trim() || !editPassword.trim()) return;
-    onEditar(
+    const ok = await onEditar(
       credenciales[editIndex].usuario,
       credenciales[editIndex].empresa || "",
       editUsuario.trim(),
       editPassword.trim()
     );
-    setEditIndex(null);
-    setEditUsuario("");
-    setEditPassword("");
+    if (ok) {
+      setEditIndex(null);
+      setEditUsuario("");
+      setEditPassword("");
+    }
   };
 
   return (
@@ -146,7 +150,9 @@ export default function AdminEmpresas({
                       <button
                         type="button"
                         className="px-2 py-0.5 text-xs bg-red-600 text-white rounded"
-                        onClick={() => onEliminar(c.usuario)}
+                        onClick={async () => {
+                          await onEliminar(c.usuario);
+                        }}
                       >
                         Eliminar
                       </button>

--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -35,14 +35,18 @@ type Props = {
   soloGenerales?: boolean;
   empresaFiltro?: string;
   credenciales?: CredencialEmpresa[];
-  onAgregarEmpresa?: (nombre: string, usuario: string, password: string) => void;
-  onEliminarEmpresa?: (usuario: string) => void;
+  onAgregarEmpresa?: (
+    nombre: string,
+    usuario: string,
+    password: string
+  ) => Promise<boolean>;
+  onEliminarEmpresa?: (usuario: string) => Promise<boolean>;
   onEditarEmpresa?: (
     originalUsuario: string,
     nombre: string,
     usuario: string,
     password: string
-  ) => void;
+  ) => Promise<boolean>;
   onBack?: () => void;
 };
 
@@ -939,9 +943,15 @@ export default function DashboardResultados({
           <TabsContent value="empresas">
             <AdminEmpresas
               credenciales={credenciales}
-              onAgregar={onAgregarEmpresa || (() => {})}
-              onEliminar={onEliminarEmpresa || (() => {})}
-              onEditar={onEditarEmpresa || (() => {})}
+              onAgregar={
+                onAgregarEmpresa || (async () => false)
+              }
+              onEliminar={
+                onEliminarEmpresa || (async () => false)
+              }
+              onEditar={
+                onEditarEmpresa || (async () => false)
+              }
             />
           </TabsContent>
         )}


### PR DESCRIPTION
## Summary
- handle Firestore failures in `agregarEmpresa`, `eliminarEmpresa`, and `editarEmpresa`
- add catch block when saving survey results
- return `Promise<boolean>` from company management helpers
- adjust AdminEmpresas and DashboardResultados props accordingly

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_685af1683f308331bcfef065fdacb871