### PR TITLE
Update demo credentials handling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,7 @@ import { calcularFormaA } from "./utils/calcularFormaA";
 import { calcularFormaB } from "./utils/calcularFormaB";
 import { calcularGlobalAExtrala, calcularGlobalBExtrala } from "./utils/calcularGlobalA";
 import removeUndefined from "./utils/removeUndefined";
+import { demoCredencialesConst } from "./data/demoCredenciales";
 
 type RolUsuario = "ninguno" | "psicologa" | "dueno";
 
@@ -65,7 +66,8 @@ export default function App() {
   const [ficha, setFicha] = useState<FichaDatos | null>(null);
 
   const demoCredenciales: (CredencialEmpresa & { rol: string })[] = JSON.parse(
-    import.meta.env.VITE_DEMO_CREDENTIALS || "[]"
+    import.meta.env.VITE_DEMO_CREDENTIALS ||
+      JSON.stringify(demoCredencialesConst)
   );
 
   const [credenciales, setCredenciales] = useState<

--- a/src/data/demoCredenciales.ts
+++ b/src/data/demoCredenciales.ts
@@ -1,0 +1,12 @@
+import { CredencialEmpresa } from "@/types";
+
+export const demoCredencialesConst: (CredencialEmpresa & { rol: string })[] = [
+  { usuario: "psicologa", password: "cogent2024", rol: "psicologa" },
+  { usuario: "sonria", password: "sonria123", rol: "dueno", empresa: "Sonria" },
+  {
+    usuario: "aeropuerto",
+    password: "eldorado123",
+    rol: "dueno",
+    empresa: "Aeropuerto El Dorado",
+  },
+];


### PR DESCRIPTION
## Summary
- add `demoCredencialesConst` with default demo credentials
- parse `VITE_DEMO_CREDENTIALS` or fall back to demo constants

## Testing
- `npm run lint` *(fails: cannot find module `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_68603e2f6b148331b985f8070c8c341b