### PR TITLE
Add reusable pie chart label helper

### DIFF
--- a/src/components/CustomPieLabel.tsx
+++ b/src/components/CustomPieLabel.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import type { PieLabelRenderProps } from "recharts";
+
+const RADIAN = Math.PI / 180;
+
+export function renderPieLabel<T extends Record<string, any>>(
+  length: number,
+  format: (payload: T) => string,
+  shortFormat?: (payload: T) => string,
+  shortenThreshold = 6
+) {
+  return ({ cx = 0, cy = 0, midAngle = 0, innerRadius = 0, outerRadius = 0, payload }: PieLabelRenderProps): React.ReactNode => {
+    const radius = innerRadius + (outerRadius - innerRadius) * 0.5;
+    const x = length === 1 ? cx : cx + radius * Math.cos(-midAngle * RADIAN);
+    const y = length === 1 ? cy : cy + radius * Math.sin(-midAngle * RADIAN);
+    const text = shortFormat && length >= shortenThreshold ? shortFormat(payload as T) : format(payload as T);
+    return (
+      <text x={x} y={y} textAnchor="middle" dominantBaseline="central" fill="var(--text-main)">
+        {text}
+      </text>
+    );
+  };
+}
+
+export default renderPieLabel;

--- a/src/components/GraficaBarra.tsx
+++ b/src/components/GraficaBarra.tsx
@@ -13,6 +13,7 @@ import {
   LabelList,
 } from "recharts";
 import { NivelResumen } from "@/types";
+import renderPieLabel from "@/components/CustomPieLabel";
 
 const gradientes = {
   "Riesgo muy bajo": { id: "riesgo-muy-bajo", from: "#bfdbfe", to: "#3b82f6" },
@@ -58,7 +59,17 @@ export default function GraficaBarra({
                 </linearGradient>
               ))}
             </defs>
-            <Pie data={resumen} dataKey="indice" nameKey="nombre" label>
+            <Pie
+              data={resumen}
+              dataKey="indice"
+              nameKey="nombre"
+              label={renderPieLabel(
+                resumen.length,
+                (payload) => `${payload.nombre}: ${payload.nivel}`,
+                (payload) => payload.nivel
+              )}
+              labelLine={false}
+            >
               {resumen.map((d, i) => (
                 <Cell key={i} fill={colorPorNivel[d.nivel as keyof typeof colorPorNivel]} />
               ))}

--- a/src/components/GraficaBarraCategorias.tsx
+++ b/src/components/GraficaBarraCategorias.tsx
@@ -13,6 +13,7 @@ import {
   ResponsiveContainer,
   LabelList,
 } from "recharts";
+import renderPieLabel from "@/components/CustomPieLabel";
 
 // Blue palette used for chart segments
 const coloresAzulFicha = [
@@ -52,9 +53,13 @@ export default function GraficaBarraCategorias({
               data={datosConPorcentaje}
               dataKey="cantidad"
               nameKey="nombre"
-              label={({ payload }) =>
-                `${payload.nombre}: ${payload.cantidad} (${payload.porcentaje.toFixed(0)}%)`
-              }
+              label={renderPieLabel(
+                datosConPorcentaje.length,
+                (payload) =>
+                  `${payload.nombre}: ${payload.cantidad} (${payload.porcentaje.toFixed(0)}%)`,
+                (payload) => `${payload.porcentaje.toFixed(0)}%`
+              )}
+              labelLine={false}
             >
               {datosConPorcentaje.map((_, i) => (
                 <Cell key={i} fill={coloresAzulFicha[i % coloresAzulFicha.length]} />

--- a/src/components/GraficaBarraSimple.tsx
+++ b/src/components/GraficaBarraSimple.tsx
@@ -13,6 +13,7 @@ import {
   LabelList,
 } from "recharts";
 import { NivelResumen } from "@/types";
+import renderPieLabel from "@/components/CustomPieLabel";
 
 const gradientes = {
 
@@ -71,9 +72,13 @@ export default function GraficaBarraSimple({
               data={datos}
               dataKey="cantidad"
               nameKey="nivel"
-              label={({ payload }) =>
-                `${payload.nivel}: ${payload.cantidad} (${payload.porcentaje.toFixed(0)}%)`
-              }
+              label={renderPieLabel(
+                datos.length,
+                (payload) =>
+                  `${payload.nivel}: ${payload.cantidad} (${payload.porcentaje.toFixed(0)}%)`,
+                (payload) => `${payload.porcentaje.toFixed(0)}%`
+              )}
+              labelLine={false}
             >
               {datos.map((d, i) => (
                 <Cell key={i} fill={colores[d.nivel as keyof typeof colores]} />


### PR DESCRIPTION
## Summary
- create `CustomPieLabel` renderer for pie charts
- apply helper to `GraficaBarra`, `GraficaBarraCategorias` and `GraficaBarraSimple`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6861b07a0a9c8331bd6b89a9d2760bbb