### PR TITLE
Improve pie chart labels and add helper

### DIFF
--- a/src/components/CustomPieLabel.tsx
+++ b/src/components/CustomPieLabel.tsx
@@ -18,9 +18,13 @@ export function renderPieLabel<T extends Record<string, any>>(
     const radius = inner + (outer - inner) * 0.5;
     const x = length === 1 ? cxNum : cxNum + radius * Math.cos(-midAngle * RADIAN);
     const y = length === 1 ? cyNum : cyNum + radius * Math.sin(-midAngle * RADIAN);
-    const text = shortFormat && length >= shortenThreshold ? shortFormat(payload as T) : format(payload as T);
+    const text =
+      shortFormat && length >= shortenThreshold
+        ? shortFormat(payload as T)
+        : format(payload as T);
     return (
       <text x={x} y={y} textAnchor="middle" dominantBaseline="central" fill="var(--text-main)">
+        <title>{format(payload as T)}</title>
         {text}
       </text>
     );

--- a/src/components/GraficaBarra.tsx
+++ b/src/components/GraficaBarra.tsx
@@ -14,6 +14,7 @@ import {
 } from "recharts";
 import { NivelResumen } from "@/types";
 import renderPieLabel from "@/components/CustomPieLabel";
+import shortNivelRiesgo from "@/utils/shortNivelRiesgo";
 
 const gradientes = {
   "Riesgo muy bajo": { id: "riesgo-muy-bajo", from: "#bfdbfe", to: "#3b82f6" },
@@ -66,7 +67,8 @@ export default function GraficaBarra({
               label={renderPieLabel(
                 resumen.length,
                 (payload) => `${payload.nombre}: ${payload.nivel}`,
-                (payload) => payload.nivel
+                (payload) => shortNivelRiesgo(payload.nivel),
+                0
               )}
               labelLine={false}
             >

--- a/src/components/GraficaBarraCategorias.tsx
+++ b/src/components/GraficaBarraCategorias.tsx
@@ -57,7 +57,8 @@ export default function GraficaBarraCategorias({
                 datosConPorcentaje.length,
                 (payload) =>
                   `${payload.nombre}: ${payload.cantidad} (${payload.porcentaje.toFixed(0)}%)`,
-                (payload) => `${payload.porcentaje.toFixed(0)}%`
+                (payload) => `${payload.porcentaje.toFixed(0)}%`,
+                0
               )}
               labelLine={false}
             >

--- a/src/components/GraficaBarraSimple.tsx
+++ b/src/components/GraficaBarraSimple.tsx
@@ -14,6 +14,7 @@ import {
 } from "recharts";
 import { NivelResumen } from "@/types";
 import renderPieLabel from "@/components/CustomPieLabel";
+import shortNivelRiesgo from "@/utils/shortNivelRiesgo";
 
 const gradientes = {
 
@@ -76,7 +77,9 @@ export default function GraficaBarraSimple({
                 datos.length,
                 (payload) =>
                   `${payload.nivel}: ${payload.cantidad} (${payload.porcentaje.toFixed(0)}%)`,
-                (payload) => `${payload.porcentaje.toFixed(0)}%`
+                (payload) =>
+                  `${shortNivelRiesgo(payload.nivel)} (${payload.porcentaje.toFixed(0)}%)`,
+                0
               )}
               labelLine={false}
             >

--- a/src/utils/shortNivelRiesgo.ts
+++ b/src/utils/shortNivelRiesgo.ts
@@ -1,0 +1,6 @@
+export default function shortNivelRiesgo(nivel: string): string {
+  const withoutPrefix = nivel.replace(/^riesgo\s+/i, "");
+  return withoutPrefix.charAt(0).toUpperCase() + withoutPrefix.slice(1);
+}
+
+export { shortNivelRiesgo };


### PR DESCRIPTION
## Summary
- add `shortNivelRiesgo` util to strip the `Riesgo` prefix
- show titles on pie labels for hover support
- support forcing short labels in GraficaBarraSimple and other charts
- use short risk names for pie labels in bar charts

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6861e2d06e90833194ac33da9082ce13