### PR TITLE
Insert background shapes in HomePage

### DIFF
--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -12,7 +12,11 @@ type Props = {
 
 export default function HomePage({ onStartSurvey, onViewResults, onPrivacy, onTerms }: Props) {
   return (
-    <div className="relative min-h-screen flex flex-col items-center justify-center bg-gradient-to-b from-[#F4F8FA] to-[#FFFFFF] overflow-hidden">
+    <div className="relative min-h-screen flex flex-col items-center justify-center overflow-hidden">
+      <div className="background-shapes">
+        <div className="shape rhombus rhombus-1"></div>
+        <div className="shape rhombus rhombus-2"></div>
+      </div>
       <svg
         className="absolute left-0 top-0 opacity-20 w-[320px] h-[320px] -z-10"
         viewBox="0 0 320 320"


### PR DESCRIPTION
## Summary
- drop Tailwind gradient from `HomePage`
- insert background shape elements so they render behind the page content

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing type declarations and modules)*

------
https://chatgpt.com/codex/tasks/task_e_6861f4511db08331801f8a26e15a1ad2