### PR TITLE
Enable rhombus backgrounds sitewide

### DIFF
--- a/src/components/BloquesDePreguntas.tsx
+++ b/src/components/BloquesDePreguntas.tsx
@@ -107,21 +107,11 @@ export default function BloquesDePreguntas({ bloques, preguntas, onFinish }: Pro
 
   // Render
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-b from-[#F4F8FA] to-[#FFFFFF] relative overflow-hidden px-2">
-      <svg
-        className="absolute left-0 top-0 opacity-10 w-[320px] h-[320px] -z-10"
-        viewBox="0 0 320 320"
-        fill="none"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <circle cx="160" cy="160" r="140" fill="url(#grad1)" />
-        <defs>
-          <linearGradient id="grad1" x1="60" y1="30" x2="260" y2="260" gradientUnits="userSpaceOnUse">
-            <stop stopColor="#2EC4FF" />
-            <stop offset="1" stopColor="#005DFF" />
-          </linearGradient>
-        </defs>
-      </svg>
+    <div className="min-h-screen flex items-center justify-center relative overflow-hidden px-2">
+      <div className="background-shapes">
+        <div className="shape rhombus rhombus-1"></div>
+        <div className="shape rhombus rhombus-2"></div>
+      </div>
 
       <div className="bg-white rounded-3xl shadow-xl p-8 md:p-12 w-full max-w-2xl mx-auto animate-fadeIn flex flex-col gap-4">
         <h3 className="font-bold text-[#132045] text-xl md:text-2xl mb-2 text-center font-montserrat">

--- a/src/components/Consentimiento.tsx
+++ b/src/components/Consentimiento.tsx
@@ -2,21 +2,11 @@ import React from "react";
 
 export default function Consentimiento({ onAceptar }: { onAceptar: () => void }) {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-b from-[#F4F8FA] to-[#FFFFFF] relative overflow-hidden px-2">
-      <svg
-        className="absolute left-0 top-0 opacity-10 w-[320px] h-[320px] -z-10"
-        viewBox="0 0 320 320"
-        fill="none"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <circle cx="160" cy="160" r="140" fill="url(#grad1)" />
-        <defs>
-          <linearGradient id="grad1" x1="60" y1="30" x2="260" y2="260" gradientUnits="userSpaceOnUse">
-            <stop stopColor="#2EC4FF" />
-            <stop offset="1" stopColor="#005DFF" />
-          </linearGradient>
-        </defs>
-      </svg>
+    <div className="min-h-screen flex items-center justify-center relative overflow-hidden px-2">
+      <div className="background-shapes">
+        <div className="shape rhombus rhombus-1"></div>
+        <div className="shape rhombus rhombus-2"></div>
+      </div>
 
       <div className="bg-white rounded-3xl shadow-xl p-8 md:p-12 w-full max-w-xl mx-auto animate-fadeIn flex flex-col items-center">
         <div className="flex items-center justify-center gap-6 mb-6">

--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -595,7 +595,11 @@ export default function DashboardResultados({
   // ---- Pestañas ----
   return (
 
-    <div className="min-h-screen bg-gradient-to-b from-[#F7FAFF] to-[#EAF3FF] flex flex-col items-center py-10 px-2">
+    <div className="min-h-screen flex flex-col items-center py-10 px-2">
+      <div className="background-shapes">
+        <div className="shape rhombus rhombus-1"></div>
+        <div className="shape rhombus rhombus-2"></div>
+      </div>
       <div
         ref={containerRef}
         className="w-full max-w-7xl bg-white rounded-2xl shadow-xl p-8 md:p-10 flex flex-col gap-8 mx-auto"

--- a/src/components/FichaDatosGenerales.tsx
+++ b/src/components/FichaDatosGenerales.tsx
@@ -141,21 +141,11 @@ export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Pr
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-b from-[#F4F8FA] to-[#FFFFFF] relative overflow-hidden px-2">
-      <svg
-        className="absolute left-0 top-0 opacity-10 w-[320px] h-[320px] -z-10"
-        viewBox="0 0 320 320"
-        fill="none"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <circle cx="160" cy="160" r="140" fill="url(#grad1)" />
-        <defs>
-          <linearGradient id="grad1" x1="60" y1="30" x2="260" y2="260" gradientUnits="userSpaceOnUse">
-            <stop stopColor="#2EC4FF" />
-            <stop offset="1" stopColor="#005DFF" />
-          </linearGradient>
-        </defs>
-      </svg>
+    <div className="min-h-screen flex items-center justify-center relative overflow-hidden px-2">
+      <div className="background-shapes">
+        <div className="shape rhombus rhombus-1"></div>
+        <div className="shape rhombus rhombus-2"></div>
+      </div>
 
       <form
 

--- a/src/components/FormSelector.tsx
+++ b/src/components/FormSelector.tsx
@@ -8,27 +8,11 @@ export default function FormSelector({
   onSelect: (form: "A" | "B") => void;
 }) {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-b from-[#F4F8FA] to-[#FFFFFF] px-2 relative overflow-hidden">
-      {/* Background decorative SVG */}
-      <svg
-        className="absolute left-0 top-0 opacity-10 w-[320px] h-[320px] -z-10"
-        viewBox="0 0 320 320"
-      >
-        <circle cx="160" cy="160" r="140" fill="url(#grad1)" />
-        <defs>
-          <linearGradient
-            id="grad1"
-            x1="60"
-            y1="30"
-            x2="260"
-            y2="260"
-            gradientUnits="userSpaceOnUse"
-          >
-            <stop stopColor="#2EC4FF" />
-            <stop offset="1" stopColor="#005DFF" />
-          </linearGradient>
-        </defs>
-      </svg>
+    <div className="min-h-screen flex items-center justify-center px-2 relative overflow-hidden">
+      <div className="background-shapes">
+        <div className="shape rhombus rhombus-1"></div>
+        <div className="shape rhombus rhombus-2"></div>
+      </div>
 
       {/* Card */}
       <div className="bg-white rounded-3xl shadow-xl p-8 md:p-12 w-full max-w-md mx-auto animate-fadeIn flex flex-col items-center">

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -13,11 +13,9 @@ type Props = {
 export default function HomePage({ onStartSurvey, onViewResults, onPrivacy, onTerms }: Props) {
   return (
     <div className="relative min-h-screen flex flex-col items-center justify-center overflow-hidden">
-      <div className="fixed top-[7vh] right-[8vw] w-[450px] h-[450px] pointer-events-none z-0">
-        <div className="absolute top-0 left-1/2 w-[160px] h-[160px] -translate-x-1/2 rotate-45 bg-gradient-to-br from-blue-600 to-blue-200 opacity-20 rounded-3xl shadow-lg"></div>
-        <div className="absolute top-1/2 right-0 w-[160px] h-[160px] -translate-y-1/2 rotate-45 bg-gradient-to-br from-blue-600 to-blue-200 opacity-20 rounded-3xl shadow-lg"></div>
-        <div className="absolute bottom-0 left-1/2 w-[160px] h-[160px] -translate-x-1/2 rotate-45 bg-gradient-to-br from-blue-600 to-blue-200 opacity-20 rounded-3xl shadow-lg"></div>
-        <div className="absolute top-1/2 left-0 w-[160px] h-[160px] -translate-y-1/2 rotate-45 bg-gradient-to-br from-blue-600 to-blue-200 opacity-20 rounded-3xl shadow-lg"></div>
+      <div className="background-shapes">
+        <div className="shape rhombus rhombus-1"></div>
+        <div className="shape rhombus rhombus-2"></div>
       </div>
 
       <div className="flex items-center justify-center gap-6 mb-8 animate-fadeIn">

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -28,17 +28,11 @@ export default function Login({ usuarios, onLogin, onCancel }: Props) {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-b from-[#F4F8FA] to-white px-2 relative">
-      {/* Decorative background */}
-      <svg className="absolute left-0 top-0 opacity-10 w-[320px] h-[320px] -z-10" viewBox="0 0 320 320">
-        <circle cx="160" cy="160" r="140" fill="url(#grad1)" />
-        <defs>
-          <linearGradient id="grad1" x1="60" y1="30" x2="260" y2="260" gradientUnits="userSpaceOnUse">
-            <stop stopColor="#2EC4FF" />
-            <stop offset="1" stopColor="#005DFF" />
-          </linearGradient>
-        </defs>
-      </svg>
+    <div className="min-h-screen flex items-center justify-center px-2 relative">
+      <div className="background-shapes">
+        <div className="shape rhombus rhombus-1"></div>
+        <div className="shape rhombus rhombus-2"></div>
+      </div>
 
       <form
         onSubmit={handleSubmit}

--- a/src/components/PoliticaPrivacidad.tsx
+++ b/src/components/PoliticaPrivacidad.tsx
@@ -4,21 +4,11 @@ type Props = { onBack: () => void };
 
 export default function PoliticaPrivacidad({ onBack }: Props) {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-b from-[#F4F8FA] to-[#FFFFFF] relative overflow-y-auto px-4 py-8">
-      <svg
-        className="absolute left-0 top-0 opacity-10 w-[320px] h-[320px] -z-10"
-        viewBox="0 0 320 320"
-        fill="none"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <circle cx="160" cy="160" r="140" fill="url(#grad1)" />
-        <defs>
-          <linearGradient id="grad1" x1="60" y1="30" x2="260" y2="260" gradientUnits="userSpaceOnUse">
-            <stop stopColor="#2EC4FF" />
-            <stop offset="1" stopColor="#005DFF" />
-          </linearGradient>
-        </defs>
-      </svg>
+    <div className="min-h-screen flex items-center justify-center relative overflow-y-auto px-4 py-8">
+      <div className="background-shapes">
+        <div className="shape rhombus rhombus-1"></div>
+        <div className="shape rhombus rhombus-2"></div>
+      </div>
 
       <div className="bg-white rounded-3xl shadow-xl p-6 md:p-10 max-w-3xl mx-auto animate-fadeIn text-[#313B4A] font-montserrat space-y-4">
         <h1 className="text-2xl md:text-3xl font-bold text-[#132045] text-center mb-2">

--- a/src/components/TerminosCondiciones.tsx
+++ b/src/components/TerminosCondiciones.tsx
@@ -4,21 +4,11 @@ type Props = { onBack: () => void };
 
 export default function TerminosCondiciones({ onBack }: Props) {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-b from-[#F4F8FA] to-[#FFFFFF] relative overflow-y-auto px-4 py-8">
-      <svg
-        className="absolute left-0 top-0 opacity-10 w-[320px] h-[320px] -z-10"
-        viewBox="0 0 320 320"
-        fill="none"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <circle cx="160" cy="160" r="140" fill="url(#grad1)" />
-        <defs>
-          <linearGradient id="grad1" x1="60" y1="30" x2="260" y2="260" gradientUnits="userSpaceOnUse">
-            <stop stopColor="#2EC4FF" />
-            <stop offset="1" stopColor="#005DFF" />
-          </linearGradient>
-        </defs>
-      </svg>
+    <div className="min-h-screen flex items-center justify-center relative overflow-y-auto px-4 py-8">
+      <div className="background-shapes">
+        <div className="shape rhombus rhombus-1"></div>
+        <div className="shape rhombus rhombus-2"></div>
+      </div>
 
       <div className="bg-white rounded-3xl shadow-xl p-6 md:p-10 max-w-3xl mx-auto animate-fadeIn text-[#313B4A] font-montserrat space-y-4">
         <h1 className="text-2xl md:text-3xl font-bold text-[#132045] text-center mb-2">

--- a/src/index.css
+++ b/src/index.css
@@ -110,7 +110,6 @@
   }
 }
 
-/*
 .background-shapes {
   position: fixed;
   inset: 0;
@@ -137,4 +136,3 @@
   opacity: 0.07;
   filter: blur(2px);
 }
-*/


### PR DESCRIPTION
## Summary
- activate rhombus CSS styles
- reuse the rhombus container on all major pages
- remove old gradient backgrounds and SVG circles

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6862024ad76483318d838c23449eae10