### PR TITLE
Apply uniform tailwind styling to data form

### DIFF
--- a/src/components/FichaDatosGenerales.tsx
+++ b/src/components/FichaDatosGenerales.tsx
@@ -160,7 +160,10 @@ export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Pr
       <div>
         <label className="block mb-1 font-semibold text-text-main">Empresa*</label>
         <select
-          className={cn("input mb-2 w-full", erroresCampos["empresa"] && "border-red-500")}
+          className={cn(
+            "input mb-2 w-full border border-gray-300 bg-white rounded-xl px-4 py-2",
+            erroresCampos["empresa"] && "border-red-500"
+          )}
           value={empresa}
           name="empresa"
           onChange={(e) => {
@@ -180,7 +183,10 @@ export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Pr
         <input
           type="date"
           name="fecha"
-          className={cn("input mb-2 w-full", erroresCampos["fecha"] && "border-red-500")}
+          className={cn(
+            "input mb-2 w-full border border-gray-300 bg-white rounded-xl px-4 py-2",
+            erroresCampos["fecha"] && "border-red-500"
+          )}
           value={datos.fecha}
           onChange={handleChange}
         />
@@ -191,7 +197,10 @@ export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Pr
           type="text"
           name="nombre"
           placeholder="Nombre completo*"
-          className={cn("input w-full md:flex-1", erroresCampos["nombre"] && "border-red-500")}
+          className={cn(
+            "input w-full md:flex-1 border border-gray-300 bg-white rounded-xl px-4 py-2",
+            erroresCampos["nombre"] && "border-red-500"
+          )}
           value={datos.nombre}
           onChange={handleChange}
         />
@@ -199,7 +208,10 @@ export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Pr
           type="text"
           name="cedula"
           placeholder="Cédula/Documento*"
-          className={cn("input w-full md:flex-1", erroresCampos["cedula"] && "border-red-500")}
+          className={cn(
+            "input w-full md:flex-1 border border-gray-300 bg-white rounded-xl px-4 py-2",
+            erroresCampos["cedula"] && "border-red-500"
+          )}
           value={datos.cedula}
           onChange={handleChange}
         />
@@ -208,7 +220,10 @@ export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Pr
       <div className="flex flex-col gap-4 md:flex-row">
         <select
           name="sexo"
-          className={cn("input w-full md:flex-1", erroresCampos["sexo"] && "border-red-500")}
+          className={cn(
+            "input w-full md:flex-1 border border-gray-300 bg-white rounded-xl px-4 py-2",
+            erroresCampos["sexo"] && "border-red-500"
+          )}
           value={datos.sexo}
           onChange={handleChange}
         >
@@ -220,7 +235,10 @@ export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Pr
           type="number"
           name="nacimiento"
           placeholder="Año de nacimiento*"
-          className={cn("input w-full md:flex-1", erroresCampos["nacimiento"] && "border-red-500")}
+          className={cn(
+            "input w-full md:flex-1 border border-gray-300 bg-white rounded-xl px-4 py-2",
+            erroresCampos["nacimiento"] && "border-red-500"
+          )}
           value={datos.nacimiento}
           onChange={handleChange}
           min={1900}
@@ -231,7 +249,10 @@ export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Pr
       <div className="flex flex-col gap-4 md:flex-row">
         <select
           name="estadoCivil"
-          className={cn("input w-full md:flex-1", erroresCampos["estadoCivil"] && "border-red-500")}
+          className={cn(
+            "input w-full md:flex-1 border border-gray-300 bg-white rounded-xl px-4 py-2",
+            erroresCampos["estadoCivil"] && "border-red-500"
+          )}
           value={datos.estadoCivil}
           onChange={handleChange}
         >
@@ -242,7 +263,10 @@ export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Pr
         </select>
         <select
           name="estudios"
-          className={cn("input w-full md:flex-1", erroresCampos["estudios"] && "border-red-500")}
+          className={cn(
+            "input w-full md:flex-1 border border-gray-300 bg-white rounded-xl px-4 py-2",
+            erroresCampos["estudios"] && "border-red-500"
+          )}
           value={datos.estudios}
           onChange={handleChange}
         >
@@ -257,7 +281,10 @@ export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Pr
         type="text"
         name="ocupacion"
         placeholder="Ocupación o profesión*"
-        className={cn("input w-full", erroresCampos["ocupacion"] && "border-red-500")}
+        className={cn(
+          "input w-full border border-gray-300 bg-white rounded-xl px-4 py-2",
+          erroresCampos["ocupacion"] && "border-red-500"
+        )}
         value={datos.ocupacion}
         onChange={handleChange}
       />
@@ -267,7 +294,10 @@ export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Pr
           type="text"
           name="residenciaCiudad"
           placeholder="Ciudad/Municipio residencia*"
-          className={cn("input w-full md:flex-1", erroresCampos["residenciaCiudad"] && "border-red-500")}
+          className={cn(
+            "input w-full md:flex-1 border border-gray-300 bg-white rounded-xl px-4 py-2",
+            erroresCampos["residenciaCiudad"] && "border-red-500"
+          )}
           value={datos.residenciaCiudad}
           onChange={handleChange}
         />
@@ -275,7 +305,10 @@ export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Pr
           type="text"
           name="residenciaDepto"
           placeholder="Departamento residencia*"
-          className={cn("input w-full md:flex-1", erroresCampos["residenciaDepto"] && "border-red-500")}
+          className={cn(
+            "input w-full md:flex-1 border border-gray-300 bg-white rounded-xl px-4 py-2",
+            erroresCampos["residenciaDepto"] && "border-red-500"
+          )}
           value={datos.residenciaDepto}
           onChange={handleChange}
         />
@@ -284,7 +317,10 @@ export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Pr
       <div className="flex flex-col gap-4 md:flex-row">
         <select
           name="estrato"
-          className={cn("input w-full md:flex-1", erroresCampos["estrato"] && "border-red-500")}
+          className={cn(
+            "input w-full md:flex-1 border border-gray-300 bg-white rounded-xl px-4 py-2",
+            erroresCampos["estrato"] && "border-red-500"
+          )}
           value={datos.estrato}
           onChange={handleChange}
         >
@@ -295,7 +331,10 @@ export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Pr
         </select>
         <select
           name="vivienda"
-          className={cn("input w-full md:flex-1", erroresCampos["vivienda"] && "border-red-500")}
+          className={cn(
+            "input w-full md:flex-1 border border-gray-300 bg-white rounded-xl px-4 py-2",
+            erroresCampos["vivienda"] && "border-red-500"
+          )}
           value={datos.vivienda}
           onChange={handleChange}
         >
@@ -310,7 +349,7 @@ export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Pr
         type="number"
         name="dependientes"
         placeholder="Nº de personas que dependen de usted*"
-        className="input w-full"
+        className="input w-full border border-gray-300 bg-white rounded-xl px-4 py-2"
         value={datos.dependientes}
         onChange={handleChange}
         min={0}
@@ -322,7 +361,10 @@ export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Pr
           type="text"
           name="trabajoCiudad"
           placeholder="Ciudad/Municipio trabajo*"
-          className={cn("input w-full md:flex-1", erroresCampos["trabajoCiudad"] && "border-red-500")}
+          className={cn(
+            "input w-full md:flex-1 border border-gray-300 bg-white rounded-xl px-4 py-2",
+            erroresCampos["trabajoCiudad"] && "border-red-500"
+          )}
           value={datos.trabajoCiudad}
           onChange={handleChange}
         />
@@ -330,7 +372,10 @@ export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Pr
           type="text"
           name="trabajoDepto"
           placeholder="Departamento trabajo*"
-          className={cn("input w-full md:flex-1", erroresCampos["trabajoDepto"] && "border-red-500")}
+          className={cn(
+            "input w-full md:flex-1 border border-gray-300 bg-white rounded-xl px-4 py-2",
+            erroresCampos["trabajoDepto"] && "border-red-500"
+          )}
           value={datos.trabajoDepto}
           onChange={handleChange}
         />
@@ -351,7 +396,10 @@ export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Pr
             type="number"
             name="aniosEmpresa"
             placeholder="¿Cuántos años en la empresa?*"
-            className={cn("input w-full md:flex-1", erroresCampos["aniosEmpresa"] && "border-red-500")}
+            className={cn(
+              "input w-full md:flex-1 border border-gray-300 bg-white rounded-xl px-4 py-2",
+              erroresCampos["aniosEmpresa"] && "border-red-500"
+            )}
             value={datos.aniosEmpresa}
             onChange={handleChange}
             min={1}
@@ -365,13 +413,19 @@ export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Pr
           type="text"
           name="cargo"
           placeholder="Nombre del cargo*"
-          className={cn("input w-full md:flex-1", erroresCampos["cargo"] && "border-red-500")}
+          className={cn(
+            "input w-full md:flex-1 border border-gray-300 bg-white rounded-xl px-4 py-2",
+            erroresCampos["cargo"] && "border-red-500"
+          )}
           value={datos.cargo}
           onChange={handleChange}
         />
         <select
           name="tipoCargo"
-          className={cn("input w-full md:flex-1", erroresCampos["tipoCargo"] && "border-red-500")}
+          className={cn(
+            "input w-full md:flex-1 border border-gray-300 bg-white rounded-xl px-4 py-2",
+            erroresCampos["tipoCargo"] && "border-red-500"
+          )}
           value={datos.tipoCargo}
           onChange={handleChange}
         >
@@ -397,7 +451,10 @@ export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Pr
             type="number"
             name="aniosCargo"
             placeholder="¿Cuántos años en el cargo?*"
-            className={cn("input w-full md:flex-1", erroresCampos["aniosCargo"] && "border-red-500")}
+            className={cn(
+              "input w-full md:flex-1 border border-gray-300 bg-white rounded-xl px-4 py-2",
+              erroresCampos["aniosCargo"] && "border-red-500"
+            )}
             value={datos.aniosCargo}
             onChange={handleChange}
             min={1}
@@ -410,7 +467,10 @@ export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Pr
         type="text"
         name="area"
         placeholder="Nombre del área/departamento/sección*"
-        className={cn("input w-full", erroresCampos["area"] && "border-red-500")}
+        className={cn(
+          "input w-full border border-gray-300 bg-white rounded-xl px-4 py-2",
+          erroresCampos["area"] && "border-red-500"
+        )}
         value={datos.area}
         onChange={handleChange}
       />
@@ -418,7 +478,10 @@ export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Pr
       <div className="flex flex-col gap-4 md:flex-row">
         <select
           name="tipoContrato"
-          className={cn("input w-full md:flex-1", erroresCampos["tipoContrato"] && "border-red-500")}
+          className={cn(
+            "input w-full md:flex-1 border border-gray-300 bg-white rounded-xl px-4 py-2",
+            erroresCampos["tipoContrato"] && "border-red-500"
+          )}
           value={datos.tipoContrato}
           onChange={handleChange}
         >
@@ -431,7 +494,10 @@ export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Pr
           type="number"
           name="horasDiarias"
           placeholder="Horas diarias establecidas*"
-          className={cn("input w-full md:flex-1", erroresCampos["horasDiarias"] && "border-red-500")}
+          className={cn(
+            "input w-full md:flex-1 border border-gray-300 bg-white rounded-xl px-4 py-2",
+            erroresCampos["horasDiarias"] && "border-red-500"
+          )}
           value={datos.horasDiarias}
           onChange={handleChange}
           min={1}
@@ -441,7 +507,10 @@ export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Pr
       {/* Tipo de salario */}
       <select
         name="tipoSalario"
-        className={cn("input w-full", erroresCampos["tipoSalario"] && "border-red-500")}
+        className={cn(
+          "input w-full border border-gray-300 bg-white rounded-xl px-4 py-2",
+          erroresCampos["tipoSalario"] && "border-red-500"
+        )}
         value={datos.tipoSalario}
         onChange={handleChange}
       >


### PR DESCRIPTION
## Summary
- add Tailwind border/background utilities to all input/select fields in `FichaDatosGenerales`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686737972f388331984677be24ca93d8