### PR TITLE
Fix filter question order in questionnaire B

### DIFF
--- a/src/data/preguntas.ts
+++ b/src/data/preguntas.ts
@@ -199,21 +199,21 @@ export const bloquesFormaB = [
   },
   {
     bloque: 12,
+    preguntas: [78, 87], // 79-88
+    enunciado: "Las siguientes preguntas están relacionadas con la satisfacción, reconocimiento y la seguridad que le ofrece su trabajo.",
+    condicional: null,
+    obligatorio: true
+  },
+  {
+    bloque: 13,
     preguntas: [88, 88], // índice de la pregunta filtro F3
     enunciado: "¿En mi trabajo debo brindar servicio a clientes o usuarios?",
     condicional: null,
     obligatorio: true
   },
   {
-    bloque: 13,
-    preguntas: [78, 87], // 80-88 (primera parte del bloque condicional, si la F3 es afirmativa)
-    enunciado: "Las siguientes preguntas están relacionadas con la satisfacción, reconocimiento y la seguridad que le ofrece su trabajo.",
-    condicional: "F3",
-    obligatorio: false
-  },
-  {
     bloque: 14,
-    preguntas: [89, 97], // 89-97 (segunda parte del bloque condicional, si la F3 es afirmativa)
+    preguntas: [89, 97], // 89-97 (solo si la respuesta anterior es afirmativa)
     enunciado: "Las siguientes preguntas continúan la valoración de satisfacción, reconocimiento y seguridad laboral.",
     condicional: "F3",
     obligatorio: false


### PR DESCRIPTION
## Summary
- place the satisfaction block before the filter question in form B so questions 79-88 always show
- keep the filter controlling only questions 89-97

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68869892a06c8331903c9ea775aa74c3