### PR TITLE
Ensure Form A feedback dimension displays on dashboard

### DIFF
--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -20,6 +20,7 @@ import LogoCogent from "/logo_forma.png";
 import { FileDown, FileText, Home as HomeIcon } from "lucide-react";
 import { collection, getDocs, deleteDoc, doc } from "firebase/firestore";
 import { db } from "@/firebaseConfig";
+import { calcularFormaA } from "@/utils/calcularFormaA";
 
 const nivelesRiesgo = [
   "Riesgo muy bajo",
@@ -162,7 +163,17 @@ export default function DashboardResultados({
   useEffect(() => {
     const cargar = async () => {
       const snap = await getDocs(collection(db, "resultadosCogent"));
-      const arr = snap.docs.map((d) => ({ id: d.id, ...(d.data() as ResultRow) }));
+      const arr = snap.docs.map((d) => {
+        const data = { id: d.id, ...(d.data() as ResultRow) };
+        if (
+          data.tipo === "A" &&
+          data.respuestas?.bloques &&
+          !data.resultadoFormaA?.dimensiones?.["Retroalimentación del desempeño"]
+        ) {
+          data.resultadoFormaA = calcularFormaA(data.respuestas.bloques);
+        }
+        return data;
+      });
       setDatos(arr);
     };
     cargar();


### PR DESCRIPTION
## Summary
- Recompute Form A results during data load when the `Retroalimentación del desempeño` dimension is missing so the dashboard displays that column.
- Import `calcularFormaA` in the dashboard to enable the on-the-fly recalculation.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 27 problems)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689641253a248331b19e7a2556097bf9