### PR TITLE
feat: add ordered headers for informe results

### DIFF
--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -111,6 +111,69 @@ const nivelesEstres = ["Muy bajo", "Bajo", "Medio", "Alto", "Muy alto"];
 const nivelesExtra = nivelesRiesgo;
 const nivelesForma = nivelesRiesgo;
 
+const fichaTecnicaHeaders = [
+  "Nro",
+  "Empresa",
+  "Sexo",
+  "Cargo",
+  "Fecha ficha",
+  "Cédula",
+  "Nacimiento",
+  "Estado civil",
+  "Estudios",
+  "Ocupación",
+  "Ciudad residencia",
+  "Departamento residencia",
+  "Estrato",
+  "Vivienda",
+  "Dependientes",
+  "Ciudad trabajo",
+  "Departamento trabajo",
+  "Años empresa",
+  "Tipo cargo",
+  "Años cargo",
+  "Área",
+  "Tipo contrato",
+  "Horas diarias",
+  "Tipo salario",
+];
+
+const informeHeaderOrder = [
+  "Nombre",
+  ...fichaTecnicaHeaders,
+  "Forma A (puntaje transformado)",
+  "Forma A (nivel de riesgo)",
+  ...dominiosA.flatMap((k) => [
+    `DOMINIO: ${k} - Forma A (puntaje transformado)`,
+    `DOMINIO: ${k} - Forma A (nivel de riesgo)`,
+  ]),
+  ...dimensionesA.flatMap((k) => [
+    `Dimensión: ${k} - Forma A (puntaje transformado)`,
+    `Dimensión: ${k} - Forma A (nivel de riesgo)`,
+  ]),
+  "Forma B (puntaje transformado)",
+  "Forma B (nivel de riesgo)",
+  ...dominiosB.flatMap((k) => [
+    `DOMINIO: ${k} - Forma B (puntaje transformado)`,
+    `DOMINIO: ${k} - Forma B (nivel de riesgo)`,
+  ]),
+  ...dimensionesB.flatMap((k) => [
+    `Dimensión: ${k} - Forma B (puntaje transformado)`,
+    `Dimensión: ${k} - Forma B (nivel de riesgo)`,
+  ]),
+  "Extralaboral (puntaje transformado)",
+  "Extralaboral (nivel de riesgo)",
+  ...dimensionesExtra.flatMap((k) => [
+    `Dimensión: ${k} - Extralaboral (puntaje transformado)`,
+    `Dimensión: ${k} - Extralaboral (nivel de riesgo)`,
+  ]),
+  "Global A+Extra (puntaje transformado)",
+  "Global A+Extra (nivel de riesgo)",
+  "Estrés (puntaje transformado)",
+  "Estrés (nivel de riesgo)",
+  "Fecha",
+];
+
 const categoriasFicha = [
   { key: "sexo", label: "Género" },
   { key: "estadoCivil", label: "Estado civil" },
@@ -437,13 +500,15 @@ export default function DashboardResultados({
     );
   }, [empresaSeleccionada]);
 
-  const allHeaders = useMemo(
-    () =>
-      Array.from(
-        new Set(datosInforme.flatMap((fila) => Object.keys(fila)))
-      ),
-    [datosInforme]
-  );
+  const allHeaders = useMemo(() => {
+    const base = informeHeaderOrder.filter((h) =>
+      datosInforme.some((fila) => h in fila)
+    );
+    const remaining = Array.from(
+      new Set(datosInforme.flatMap((fila) => Object.keys(fila)))
+    ).filter((h) => !base.includes(h));
+    return [...base, ...remaining];
+  }, [datosInforme]);
 
   const promedioInforme = useMemo(() => {
     const nivelesMap: Record<string, number> = {};

--- a/src/utils/gatherResults.ts
+++ b/src/utils/gatherResults.ts
@@ -26,9 +26,9 @@ export function gatherFlatResults(almacenados: ResultRow[]): FlatResult[] {
 
   return almacenados.map((d, idx) => {
     const fila: FlatResult = {
+      Nombre: d.ficha?.nombre || "",
       Nro: idx + 1,
       Empresa: d.ficha?.empresa || "",
-      Nombre: d.ficha?.nombre || "",
       Sexo: d.ficha?.sexo || "",
       Cargo: d.ficha?.cargo || "",
       "Fecha ficha": d.ficha?.fecha || "",
@@ -62,32 +62,34 @@ export function gatherFlatResults(almacenados: ResultRow[]): FlatResult[] {
     };
 
     if (d.resultadoFormaA) {
-      fila["Puntaje Forma A"] =
+      fila["Forma A (puntaje transformado)"] =
         d.resultadoFormaA.total?.transformado ?? "";
-      fila["Nivel Forma A"] = d.resultadoFormaA.total?.nivel ?? "";
+      fila["Forma A (nivel de riesgo)"] = d.resultadoFormaA.total?.nivel ?? "";
       const domA = d.resultadoFormaA.dominios || {};
       Object.keys(domA).forEach((k) => {
         const v = domA[k] as DimensionResultado & { puntajeTransformado?: number };
-        fila[`A ${k}`] = v.transformado ?? v.puntajeTransformado ?? "";
-        fila[`Nivel A ${k}`] = v.nivel ?? "";
+        fila[`DOMINIO: ${k} - Forma A (puntaje transformado)`] =
+          v.transformado ?? v.puntajeTransformado ?? "";
+        fila[`DOMINIO: ${k} - Forma A (nivel de riesgo)`] = v.nivel ?? "";
       });
       const dimA = d.resultadoFormaA.dimensiones || {};
       Object.keys(dimA).forEach((k) => {
         const v = dimA[k] as DimensionResultado & { puntajeTransformado?: number };
-        fila[`A ${k}`] = v.transformado ?? v.puntajeTransformado ?? "";
-        fila[`Nivel A ${k}`] = v.nivel ?? "";
+        fila[`Dimensión: ${k} - Forma A (puntaje transformado)`] =
+          v.transformado ?? v.puntajeTransformado ?? "";
+        fila[`Dimensión: ${k} - Forma A (nivel de riesgo)`] = v.nivel ?? "";
       });
     }
 
     if (d.resultadoFormaB) {
       const resB = d.resultadoFormaB as IntralaboralResultadoCompat;
-      fila["Puntaje Forma B"] =
+      fila["Forma B (puntaje transformado)"] =
         resB.total?.transformado ??
         resB.puntajeTransformadoTotal ??
         resB.puntajeTransformado ??
         resB.puntajeTotalTransformado ??
         "";
-      fila["Nivel Forma B"] =
+      fila["Forma B (nivel de riesgo)"] =
         resB.total?.nivel ??
         resB.nivelTotal ??
         resB.nivel ??
@@ -95,39 +97,46 @@ export function gatherFlatResults(almacenados: ResultRow[]): FlatResult[] {
       const domB = resB.dominios || {};
       Object.keys(domB).forEach((k) => {
         const v = domB[k] as DimensionResultado & { puntajeTransformado?: number };
-        fila[`B ${k}`] = v.transformado ?? v.puntajeTransformado ?? "";
-        fila[`Nivel B ${k}`] = v.nivel ?? "";
+        fila[`DOMINIO: ${k} - Forma B (puntaje transformado)`] =
+          v.transformado ?? v.puntajeTransformado ?? "";
+        fila[`DOMINIO: ${k} - Forma B (nivel de riesgo)`] = v.nivel ?? "";
       });
       const dimB = resB.dimensiones || {};
       Object.keys(dimB).forEach((k) => {
         const v = dimB[k] as DimensionResultado & { puntajeTransformado?: number };
-        fila[`B ${k}`] = v.transformado ?? v.puntajeTransformado ?? "";
-        fila[`Nivel B ${k}`] = v.nivel ?? "";
+        fila[`Dimensión: ${k} - Forma B (puntaje transformado)`] =
+          v.transformado ?? v.puntajeTransformado ?? "";
+        fila[`Dimensión: ${k} - Forma B (nivel de riesgo)`] = v.nivel ?? "";
       });
     }
 
     if (d.resultadoExtralaboral) {
-      fila["Puntaje Extralaboral"] =
+      fila["Extralaboral (puntaje transformado)"] =
         d.resultadoExtralaboral.puntajeTransformadoTotal ?? "";
-      fila["Nivel Extralaboral"] = d.resultadoExtralaboral.nivelGlobal ?? "";
+      fila["Extralaboral (nivel de riesgo)"] =
+        d.resultadoExtralaboral.nivelGlobal ?? "";
       const dims: ResultadoExtraDimension[] =
         d.resultadoExtralaboral.dimensiones || [];
       dims.forEach((dim) => {
         const valor = dim.puntajeTransformado ?? dim.transformado ?? "";
-        fila[`Extra ${dim.nombre}`] = valor;
-        fila[`Nivel Extra ${dim.nombre}`] = dim.nivel ?? "";
+        fila[`Dimensión: ${dim.nombre} - Extralaboral (puntaje transformado)`] =
+          valor;
+        fila[`Dimensión: ${dim.nombre} - Extralaboral (nivel de riesgo)`] =
+          dim.nivel ?? "";
       });
     }
 
     if (d.resultadoGlobalAExtralaboral) {
-      fila["Puntaje Global A+Extra"] =
+      fila["Global A+Extra (puntaje transformado)"] =
         d.resultadoGlobalAExtralaboral.puntajeGlobal ?? "";
-      fila["Nivel Global"] = d.resultadoGlobalAExtralaboral.nivelGlobal ?? "";
+      fila["Global A+Extra (nivel de riesgo)"] =
+        d.resultadoGlobalAExtralaboral.nivelGlobal ?? "";
     }
 
     if (d.resultadoEstres) {
-      fila["Puntaje Estrés"] = d.resultadoEstres.puntajeTransformado ?? "";
-      fila["Nivel Estrés"] = d.resultadoEstres.nivel ?? "";
+      fila["Estrés (puntaje transformado)"] =
+        d.resultadoEstres.puntajeTransformado ?? "";
+      fila["Estrés (nivel de riesgo)"] = d.resultadoEstres.nivel ?? "";
     }
 
     fila["Fecha"] = d.fecha ? new Date(d.fecha).toLocaleString() : "";


### PR DESCRIPTION
## Summary
- rename informe flat results using stakeholder labels and put "Nombre" first
- enforce a fixed informe header order based on provided labels

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689776a90b9883318e3c28eae9f5f900