### PR TITLE
fix extra closing div in Consentimiento

### DIFF
--- a/src/components/Consentimiento.tsx
+++ b/src/components/Consentimiento.tsx
@@ -198,6 +198,5 @@ export default function Consentimiento({ onAceptar }: { onAceptar: () => void })
           Acepto y deseo continuar
         </button>
       </div>
-    </div>
   );
 }


### PR DESCRIPTION
## Summary
- remove an extra closing div in Consentimiento component so JSX compiles

## Testing
- `npm run lint` *(fails: Unexpected any and unused vars in other files)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897daec597083318781b3f1769fbbd3