### PR TITLE
Fix Consentimiento layout column alignment

### DIFF
--- a/src/components/Consentimiento.tsx
+++ b/src/components/Consentimiento.tsx
@@ -176,8 +176,6 @@ export default function Consentimiento({ onAceptar }: { onAceptar: () => void })
               />
             </p>
           </div>
-        </div>
-
         <div className="text-xs text-center text-[#313B4A] font-montserrat mb-8 space-y-1">
           <p>Versión: 01</p>
           <p>Fecha: febrero 2023</p>
@@ -198,5 +196,6 @@ export default function Consentimiento({ onAceptar }: { onAceptar: () => void })
           Acepto y deseo continuar
         </button>
       </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- keep version footer and continue button inside the main Consentimiento card to maintain single-column layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: existing lint errors in unrelated files)*
- `npx eslint src/components/Consentimiento.tsx`

------
https://chatgpt.com/codex/tasks/task_e_6897dd7972a8833197f454db70ff10fd