### PR TITLE
fix ReportePDF JSX types and chart type usage

### DIFF
--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -1164,8 +1164,20 @@ export default function DashboardResultados({
                   ),
                 }}
                 graficos={{
-                  formaA: <GraficaBarraSimple resumen={resumenA} titulo="Niveles de Forma A" />, 
-                  formaB: <GraficaBarraSimple resumen={resumenB} titulo="Niveles de Forma B" />, 
+                  formaA: (
+                    <GraficaBarraSimple
+                      resumen={resumenA}
+                      titulo="Niveles de Forma A"
+                      chartType={chartType}
+                    />
+                  ),
+                  formaB: (
+                    <GraficaBarraSimple
+                      resumen={resumenB}
+                      titulo="Niveles de Forma B"
+                      chartType={chartType}
+                    />
+                  ),
                   extralaboral: (
                     <GraficaBarraCategorias
                       datos={resumenExtra.map(r => ({ nombre: r.nombre, cantidad: r.cantidad })) as CategoriaConteo[]}
@@ -1207,8 +1219,20 @@ export default function DashboardResultados({
                   ),
                 }}
                 graficos={{
-                  formaA: <GraficaBarraSimple resumen={resumenA} titulo="Niveles de Forma A" />, 
-                  formaB: <GraficaBarraSimple resumen={resumenB} titulo="Niveles de Forma B" />, 
+                  formaA: (
+                    <GraficaBarraSimple
+                      resumen={resumenA}
+                      titulo="Niveles de Forma A"
+                      chartType={chartType}
+                    />
+                  ),
+                  formaB: (
+                    <GraficaBarraSimple
+                      resumen={resumenB}
+                      titulo="Niveles de Forma B"
+                      chartType={chartType}
+                    />
+                  ),
                   extralaboral: (
                     <GraficaBarraCategorias
                       datos={resumenExtra.map(r => ({ nombre: r.nombre, cantidad: r.cantidad })) as CategoriaConteo[]}

--- a/src/components/ReportePDF.tsx
+++ b/src/components/ReportePDF.tsx
@@ -10,14 +10,14 @@ type Props = {
     estres?: { puntaje: number; nivel: string };
   };
   tablas: {
-    sociodemo?: JSX.Element;
-    intralaboral?: JSX.Element;
-    extralaboral?: JSX.Element;
+    sociodemo?: React.ReactNode;
+    intralaboral?: React.ReactNode;
+    extralaboral?: React.ReactNode;
   };
   graficos: {
-    formaA?: JSX.Element;
-    formaB?: JSX.Element;
-    extralaboral?: JSX.Element;
+    formaA?: React.ReactNode;
+    formaB?: React.ReactNode;
+    extralaboral?: React.ReactNode;
   };
   recomendaciones: string[];
   conclusiones: string;


### PR DESCRIPTION
## Summary
- include chartType prop when rendering GraficaBarraSimple in DashboardResultados report PDF
- replace JSX.Element with React.ReactNode in ReportePDF props to resolve JSX namespace errors

## Testing
- `npm run lint` *(fails: nivelesRiesgo unused, unexpected any, etc.)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6897f5502d248331852c1a74e585f813