### PR TITLE
feat: improve PDF export with progress

### DIFF
--- a/src/hooks/usePdfExport.ts
+++ b/src/hooks/usePdfExport.ts
@@ -1,0 +1,24 @@
+import { useRef, useState } from "react";
+import { exportElementToPDF } from "@/utils/pdfExport";
+
+export function usePdfExport() {
+  const ref = useRef<HTMLDivElement>(null);
+  const [rendering, setRendering] = useState(false);
+  const [progress, setProgress] = useState<string>("");
+
+  async function exportNow(filename: string) {
+    setRendering(true);
+    setProgress("Montando informe…");
+    await new Promise((r) => setTimeout(r, 350)); // dejar que React pinte
+    if (ref.current) {
+      await exportElementToPDF(ref.current, filename, {
+        scale: 1.2,
+        onProgress: setProgress,
+      });
+    }
+    setRendering(false);
+    setProgress("");
+  }
+
+  return { ref, rendering, progress, exportNow };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -113,3 +113,4 @@
 
 @page { size: A4; margin: 24pt; }
 .page-break { page-break-before: always; }
+h1, h2, h3, ul, li, table { page-break-inside: avoid; }

--- a/src/utils/pdfExport.ts
+++ b/src/utils/pdfExport.ts
@@ -1,21 +1,81 @@
 import { jsPDF } from "jspdf";
 
-/**
- * Exporta un elemento HTML a un archivo PDF utilizando jsPDF.
- * @param element Elemento a renderizar en el PDF.
- * @param fileName Nombre del archivo a generar.
- */
+type PdfExportOptions = {
+  filename?: string;
+  scale?: number; // calidad html2canvas
+  onProgress?: (msg: string) => void;
+  top?: number; right?: number; bottom?: number; left?: number; // márgenes pt
+};
+
+async function waitForImages(el: HTMLElement) {
+  const imgs = Array.from(el.querySelectorAll("img"));
+  await Promise.all(
+    imgs.map((img) => {
+      const i = img as HTMLImageElement;
+      if (i.complete) return Promise.resolve(null);
+      return new Promise((res) => {
+        i.addEventListener("load", () => res(null), { once: true });
+        i.addEventListener("error", () => res(null), { once: true });
+      });
+    })
+  );
+}
+
+async function idle(ms = 150) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/** Espera simple a que Recharts/SVGs tengan medidas > 0 */
+async function waitForCharts(el: HTMLElement, tries = 10) {
+  for (let i = 0; i < tries; i++) {
+    const charts = Array.from(el.querySelectorAll("svg, canvas")) as (
+      | SVGElement
+      | HTMLCanvasElement
+    )[];
+    const ok =
+      charts.length === 0 ||
+      charts.every((c) => {
+        const bb = c.getBoundingClientRect?.();
+        return bb && bb.width > 0 && bb.height > 0;
+      });
+    if (ok) return;
+    await idle(200);
+  }
+}
+
 export async function exportElementToPDF(
   element: HTMLElement,
-  fileName: string
+  fileName: string,
+  opts: PdfExportOptions = {}
 ): Promise<void> {
+  const {
+    scale = 1.2,
+    onProgress,
+    top = 24,
+    right = 24,
+    bottom = 24,
+    left = 24,
+  } = opts;
+  void bottom;
+
+  onProgress?.("Preparando contenido…");
+  await waitForImages(element);
+  await waitForCharts(element);
+  await idle(100);
+
   const doc = new jsPDF({ orientation: "p", unit: "pt", format: "a4" });
 
+  onProgress?.("Renderizando a PDF…");
   await doc.html(element, {
-    html2canvas: { scale: 0.7 },
-    margin: [40, 40, 40, 40],
+    x: left,
+    y: top,
+    html2canvas: { scale },
+    autoPaging: "text",
+    width: 595.28 - left - right, // A4 width en pt
+    windowWidth: 1123,
     callback: () => {
-      doc.save(fileName);
+      onProgress?.("Descargando…");
+      doc.save(fileName || "informe.pdf");
     },
   });
 }


### PR DESCRIPTION
## Summary
- enhance pdf export utility with loading checks, margins and progress callback
- add usePdfExport hook to manage export state and progress
- integrate hook into DashboardResultados with offscreen rendering and button feedback
- add print CSS to avoid page breaks inside common elements

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 28 problems – existing lint issues)*

------
https://chatgpt.com/codex/tasks/task_e_6897fa68c6cc8331b9e9b002aa275b39