### PR TITLE
Add placeholder subtabs in Informe tab

### DIFF
--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -19,6 +19,7 @@ import AdminEmpresas from "@/components/AdminEmpresas";
 import { CredencialEmpresa, ResultRow, CategoriaConteo } from "@/types";
 import GeneralResultsTabs from "@/components/dashboard/GeneralResultsTabs";
 import FormaTabs from "@/components/dashboard/FormaTabs";
+import InformeTabs from "@/components/dashboard/InformeTabs";
 import LogoCogent from "/logo_forma.png";
 import { FileDown, FileText, Home as HomeIcon } from "lucide-react";
 import { collection, getDocs, deleteDoc, doc } from "firebase/firestore";
@@ -1229,57 +1230,7 @@ export default function DashboardResultados({
                     <p className="text-xs text-gray-500 mt-2">{progress}</p>
                   )}
                 </div>
-                <ReportePDF
-                  empresa={{
-                    nombre: reportPayload.empresa.nombre,
-                    nit: reportPayload.empresa.nit,
-                    logoUrl: reportPayload.empresa.logoUrl,
-                  }}
-                  fechaInformeISO={reportPayload.fechaInformeISO}
-                  global={reportPayload.global}
-                  tablas={{
-                  sociodemo: <TablaIndividual datos={datosMostrados} tipo="formaA" />,
-                  intralaboral: (
-                    <div className="space-y-6">
-                      <TablaDominios datos={datosA} dominios={dominiosA} keyResultado="resultadoFormaA" />
-                      <TablaDimensiones datos={datosA} dimensiones={dimensionesA} keyResultado="resultadoFormaA" />
-                    </div>
-                  ),
-                  extralaboral: (
-                    <TablaDimensiones
-                      datos={datosExtra}
-                      dimensiones={dimensionesExtra}
-                      keyResultado="resultadoExtralaboral"
-                    />
-                  ),
-                }}
-                graficos={{
-                  formaA: (
-                    <GraficaBarraSimple
-                      resumen={resumenA}
-                      titulo="Niveles de Forma A"
-                      chartType={chartType}
-                    />
-                  ),
-                  formaB: (
-                    <GraficaBarraSimple
-                      resumen={resumenB}
-                      titulo="Niveles de Forma B"
-                      chartType={chartType}
-                    />
-                  ),
-                  extralaboral: (
-                    <GraficaBarraCategorias
-                      datos={resumenExtra.map((r) => ({ nombre: r.nombre, cantidad: r.cantidad })) as CategoriaConteo[]}
-                      titulo="Niveles Extralaborales"
-                      chartType={chartType}
-                    />
-                  ),
-                }}
-                recomendaciones={recomendaciones}
-                conclusiones={conclusiones}
-                options={reportOptions}
-              />
+                <InformeTabs tabClass={tabPill} />
             </section>
           </div>
 

--- a/src/components/dashboard/InformeTabs.tsx
+++ b/src/components/dashboard/InformeTabs.tsx
@@ -1,0 +1,33 @@
+import { useState } from "react";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+
+export default function InformeTabs({ tabClass }: { tabClass: string }) {
+  const [value, setValue] = useState("introduccion");
+  return (
+    <Tabs value={value} onValueChange={setValue} className="w-full">
+      <TabsList className="mb-6 py-2 px-4 scroll-pl-4 w-full flex gap-2 overflow-x-auto whitespace-nowrap">
+        <TabsTrigger className={tabClass} value="introduccion">
+          Introducción
+        </TabsTrigger>
+        <TabsTrigger className={tabClass} value="generalidades">
+          Generalidades
+        </TabsTrigger>
+        <TabsTrigger className={tabClass} value="metodologia">
+          Metodología
+        </TabsTrigger>
+        <TabsTrigger className={tabClass} value="resultados">
+          Resultados
+        </TabsTrigger>
+        <TabsTrigger className={tabClass} value="estrategias">
+          Estrategias
+        </TabsTrigger>
+      </TabsList>
+      <TabsContent value="introduccion" />
+      <TabsContent value="generalidades" />
+      <TabsContent value="metodologia" />
+      <TabsContent value="resultados" />
+      <TabsContent value="estrategias" />
+    </Tabs>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add InformeTabs component with five placeholder subtabs
- integrate InformeTabs into DashboardResultados 'Informe' section

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 25 errors, 2 warnings)


------
https://chatgpt.com/codex/tasks/task_e_6898c353cc408331aa3696d54a28afc6