### PR TITLE
Agregar autocompletado de datos en introducción del informe

### DIFF
--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -20,6 +20,7 @@ import { CredencialEmpresa, ResultRow, CategoriaConteo } from "@/types";
 import GeneralResultsTabs from "@/components/dashboard/GeneralResultsTabs";
 import FormaTabs from "@/components/dashboard/FormaTabs";
 import InformeTabs from "@/components/dashboard/InformeTabs";
+import type { IntroduccionData } from "@/report/introduccion";
 import LogoCogent from "/logo_forma.png";
 import { FileDown, FileText, Home as HomeIcon } from "lucide-react";
 import { collection, getDocs, deleteDoc, doc } from "firebase/firestore";
@@ -390,6 +391,9 @@ export default function DashboardResultados({
   const datosGlobalAE = datosMostrados.filter((d) => d.resultadoGlobalAExtralaboral);
   const datosGlobalBE = datosMostrados.filter((d) => d.resultadoGlobalBExtralaboral);
 
+  const ciudadInforme =
+    datosMostrados.find((d) => d.ficha?.trabajoCiudad)?.ficha?.trabajoCiudad || "";
+
   // ---- Resúmenes para gráficos ----
   const resumenNivel = (datos: ResultRow[], key: string, niveles: string[]) =>
     niveles.map((nivel, idx) => ({
@@ -741,6 +745,14 @@ export default function DashboardResultados({
     resumenExtra: resumenExtraReport,
     estresGlobal: undefined,
   });
+
+  const introData: IntroduccionData = {
+    empresa: reportPayload.empresa.nombre,
+    total: datosMostrados.length,
+    formaA: datosA.length,
+    formaB: datosB.length,
+    ciudad: ciudadInforme,
+  };
 
   const empresaId = reportPayload.empresa?.id || "empresa-actual";
 
@@ -1230,7 +1242,7 @@ export default function DashboardResultados({
                     <p className="text-xs text-gray-500 mt-2">{progress}</p>
                   )}
                 </div>
-                <InformeTabs tabClass={tabPill} />
+                <InformeTabs tabClass={tabPill} introduccionData={introData} />
             </section>
           </div>
 

--- a/src/components/dashboard/InformeTabs.tsx
+++ b/src/components/dashboard/InformeTabs.tsx
@@ -1,8 +1,21 @@
 import { useState } from "react";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import {
+  buildIntroduccion,
+  type IntroduccionData,
+} from "@/report/introduccion";
 
-export default function InformeTabs({ tabClass }: { tabClass: string }) {
+interface Props {
+  tabClass: string;
+  introduccionData: IntroduccionData;
+}
+
+export default function InformeTabs({
+  tabClass,
+  introduccionData,
+}: Props) {
   const [value, setValue] = useState("introduccion");
+  const intro = buildIntroduccion(introduccionData);
   return (
     <Tabs value={value} onValueChange={setValue} className="w-full">
       <TabsList className="mb-6 py-2 px-4 scroll-pl-4 w-full flex gap-2 overflow-x-auto whitespace-nowrap">
@@ -22,7 +35,13 @@ export default function InformeTabs({ tabClass }: { tabClass: string }) {
           Estrategias
         </TabsTrigger>
       </TabsList>
-      <TabsContent value="introduccion" />
+      <TabsContent value="introduccion">
+        <div className="text-[#313B4A] text-justify font-montserrat text-base leading-relaxed space-y-4">
+          {intro.split("\n\n").map((p, i) => (
+            <p key={i}>{p}</p>
+          ))}
+        </div>
+      </TabsContent>
       <TabsContent value="generalidades" />
       <TabsContent value="metodologia" />
       <TabsContent value="resultados" />

--- a/src/report/introduccion.ts
+++ b/src/report/introduccion.ts
@@ -1,0 +1,213 @@
+const template = `Todos los individuos activamente laborales se encuentran expuestos a diferentes
+factores de Riesgo, entre los que destacamos Físicos, químicos, Biomecánicos,
+condiciones de seguridad, fenómenos naturales, psicosociales entre otros;
+exposiciones que son dadas por la naturaleza del cargo que se ocupa y el contexto en
+que esta se desarrolla, la exposición a estos peligros puede ocasionar enfermedades
+laborales, accidentes o incidentes laborales. Es importante comprender la relación
+causal que existe entre los riesgos psicosociales y las patologías psicosomáticas, que
+pueden impactar el desarrollo del individuo durante la ejecución del trabajo en el
+contexto laboral, el instrumento batería de riesgo psicosocial tiene como finalidad
+reconocer cuales son las condiciones psicosociales que generan riesgo en la
+población trabajadora y que no se tienen identificadas; Su finalidad brindara
+acompañamiento, orientación y mejora la calidad de los procesos y sus efectos
+adversos. La resolución 2764 de 2022, nos insta a, ¨ Desarrollar acciones de
+promoción en salud mental, identificar, prevenir, intervenir y canalizar hacia los
+servicios de atención en salud mental, en el marco del acompañamiento y apoyo a los
+empleadores y sus trabajadores afiliados. ¨.,El(La) [EMPRESA], ha aplicado la batería de riesgos Psicosocial teniendo en cuenta una
+muestra representativa de [TOTAL] trabajadores de los cuales [FORMA_A] hicieron parte de la forma
+A y [FORMA_B] de la forma B; su aplicación se generó a traves del aplicativo cogent en [CIUDAD].
+El instrumento Incluye el consentimiento informado, los cuestionarios Forma A,
+Forma B, ficha de datos generales, Cuestionario de estrés y Factor extralaboral.
+Durante su aplicación se validaron factores intralaborales como recompensas,
+demandas del trabajo, control sobre el trabajo, liderazgo, relaciones sociales en el
+trabajo, Retroalimentación del desempeño, relación con los colaboradores, control
+sobre el trabajo, claridad del rol, capacitaciones, participación y manejo del cambio,
+oportunidades para el uso y desarrollo de habilidades de conocimiento, demandas del
+trabajo, reconocimiento y compensación, recompensas derivadas de la pertinencia a
+
+la organización, Factor estrés y factor extralaboral.
+Las Encuestas Nacionales de Condiciones de Seguridad y Salud en el Trabajo, llevadas a
+cabo por el Ministerio del Trabajo en 2007 y 2013, concluyen que dentro de los factores
+de riesgo de mayor prevalencia en el ambiente laboral en Colombia los más prioritarios
+son los psicosociales y los ergonómicos por tal razón, fue emitida, por parte del
+Ministerio de la Protección Social, la Resolución 2646 de 2008, la cual establece los
+lineamientos que deben cumplir todas las empresas para la identificación, evaluación,
+prevención, intervención y monitoreo de la exposición a factores de riesgo psicosocial,
+así como el estudio y determinación de patologías presuntamente causadas por el estrés
+laboral, la cual aplica a todos los empleadores públicos y privados del país.
+
+Para entender el alcance de la aplicación de la resolución 2646 de 2008, es
+necesario revisar el concepto de “factores de riesgo psicosocial”. El Comité Mixto de la
+Organización Internacional del Trabajo sobre Medicina del Trabajo (1984), define los
+factores de riesgo psicosocial como “la interacción entre el trabajo, su medio ambiente,
+la satisfacción en el trabajo y las condiciones de su organización, por una parte, y por
+otra, las capacidades del trabajador, sus necesidades, su cultura y su satisfacción fuera
+del trabajo, todo lo cual a través de percepciones y experiencias, pueden influir en la
+salud, el rendimiento y la satisfacción en el trabajo.”
+Teniendo en cuenta la anterior definición, los factores de riesgo psicosocial incluyen
+aspectos asociados a situaciones propias del contexto de la empresa (intralaborales),
+aquellas que rodean al trabajador fuera de la empresa (extralaborales) y las que hacen
+referencia a las características del trabajador (individuales). Asimismo, se tiene en
+cuenta la resolución 2764 de 2022, por la cual se adopta la batería de instrumentos para
+la evaluación de factores de Riesgo Psicosocial, la guía técnica general para la
+promoción, prevención e intervención de los factores psicosociales y sus efectos en la
+población colaboradora, sus protocolos específicos y se dictan otras disposiciones. la
+cual no deroga las mencionadas exigencias, al contrario, reglamenta y obliga el
+monitoreo por parte de los empleadores de acuerdo al nivel de riesgo de las
+organizaciones y obliga la
+aplicación a todos los empleados tanto públicos como privados.
+
+3. Objetivo General
+Identificar los factores de riesgos psicosociales, presentes en la empresa, Mediante la
+aplicación, tabulación y análisis de la batería de instrumentos para la evaluación de
+riesgos psicosociales establecida por el ministerio de la protección social en la
+resolución 2646 de 2008, y resolución 2764 de 2022, los cuales pueden estar
+afectando negativamente el desempeño y la productividad de los empleados desde su
+área.
+
+4. Alcance
+La batería de riesgo psicosocial da alcance al 100% de la población trabajadora,
+jefes, profesionales, personal operativo y administrativo.
+
+5. Aspectos Normativos
+Comité mixto OIT Y OMS (1984), afirman que las interacciones entre el trabajo, su
+medio ambiente, la satisfacción el trabajo, las condiciones de la organización, las
+capacidades del trabajador, sus necesidades, su cultura y su situación personal fuera
+del trabajo pueden influir notoriamente en la salud rendimiento y satisfacción de los
+trabajadores.
+Ley 1562 Del 11 De julio De 2012: Por la cual se modifica el Sistema de Riesgos
+Laborales y se dictan otras disposiciones en materia de Salud Ocupacional.
+
+El artículo 22. Del decreto ley 1295 de 1994: “Todo colaborador afiliado al Sistema
+General de Riesgos Profesionales, está obligado a cuidar de su salud e informar al
+empleador información clara, veraz y completa sobre su estado de salud”.
+
+La ley 1010 de 2006 “por medio de la cual se adoptan medidas para prevenir, corregir y
+sancionar el acoso laboral y otros hostigamientos en el marco de las relaciones de trabajo”
+
+estimula la prevención y control de los factores de riesgo psicosocial.
+
+Resolución 2404 de 2019 Por la cual se adopta la Batería de Instrumentos para la
+Evaluación de Factores de Riesgo Psicosocial, la Guía Técnica General para la
+Promoción, Prevención e Intervención de los Factores Psicosociales y sus Efectos en la
+Población Trabajadora y sus Protocolos Específicos y se dictan otras disposiciones. De
+evitar que se presenten situaciones de violencia y hostigamiento en los lugares de trabajo.
+
+Resolución 2646 de 2008 que “establece disposiciones y responsabilidades para la
+identificación, evaluación, intervención y monitoreo de factores de riesgo psicosocial
+presentes en el trabajo”, formaliza la obligación de las empresas de realizar la vigilancia
+epidemiológica de dichos factores.
+
+Resolución 2764 de 2022, Por la cual se adopta la Batería de instrumentos para la
+evaluación de factores de Riesgo Psicosocial, la Guía Técnica General para la promoción,
+prevención e intervención de los factores psicosociales y sus efectos en la población
+trabajadora y sus protocolos específicos y se dictan otras disposiciones. Esta resolución
+deroga la resolución 2404 de 2019.
+La resolución 652 de 2012 por la cual se establece la conformación y funcionamiento del
+comité de convivencia laboral en entidades públicas y empresas privadas, con el fin de
+prevenir el acoso laboral.
+
+Resolución 1356 julio 18 de 2012. Por la cual se modifica parcialmente la Resolución
+652 de 2012 y se amplía el plazo, con el fin de que las empresas dispongan de más tiempo
+para realizar los procedimientos internos requeridos para la conformación del Comité de
+Convivencia Laboral.
+
+La ley 1616 de 2013, cuyo objeto es garantizar el ejercicio pleno del derecho a la salud
+mental a la población colombiana mediante la promoción de la salud y la prevención del
+trastorno mental en el ámbito del sistema general de seguridad social en salud, en su
+artículo 9 referente a promoción de la salud mental y prevención del trastorno mental en
+el ámbito laboral.
+
+El decreto 1477 de 2014 a través del cual se expidió la tabla de enfermedades laborales y
+en el cual se establecieron los factores de riesgo ocupacional a tener en cuenta para la
+prevención de enfermedades laborales psicosociales que puede presentarse en cualquier
+colaborador y puesto de trabajo, así como actividad laboral en la que existan agentes
+causales y demuestre la relación con el perjuicio a la salud. En esta nueva tabla se incluye
+el síndrome de agotamiento profesional (síndrome de burnout) como una de las
+enfermedades laborales del grupo IV: trastornos mentales y del comportamiento.
+
+Decreto 1443 de 2014, estableció las disposiciones para la implementación del Sistema
+de Gestión de Seguridad y Salud en el Trabajo (SGSST). En su artículo 3 referente a
+Seguridad y Salud en el Trabajo - SST.
+
+Decreto 1072 de 2015 En su Libro 2 Titulo 4 Capitulo 6 “Sistema de Gestión de la
+Seguridad y Salud en el Trabajo”.
+Resolución 0312 de 2019, Deroga a la Resolución 1111 de 2017 dentro de la
+normatividad en seguridad y salud en el trabajo, estableciendo de esta manera los
+nuevos estándares mínimos para el Sistema de Gestión de Seguridad y Salud en el
+Trabajo y la implementación del SGSST de una empresa.
+6. Definiciones
+
+Condiciones De Trabajo: Todos los aspectos intralaborales, extralaborales e individuales
+que están presentes al realizar una labor encaminada a la producción de bienes, servicios
+y/o conocimientos (Res. 2764 de 2022 del Ministerio de la Protección Social).
+
+Estrés: Respuesta de una persona tanto a nivel fisiológico, psicológico como conductual,
+en su intento de adaptarse a las demandas resultantes de la interacción de sus condiciones
+individuales, intralaborales y extralaborales (Res. 2764/2022 del Ministerio de la
+Protección Social).
+
+Efectos En La Salud: Alteraciones que pueden manifestarse mediante síntomas subjetivos
+
+o signos, ya sea en forma aislada o formando parte de un cuadro o diagnóstico clínico (Res.
+2764 de 2022 del Ministerio de la Protección Social).
+
+Efectos En El Trabajo: Consecuencias en el medio laboral y en los resultados del trabajo.
+Estas incluyen el ausentismo, la accidentalidad, la rotación de mano de obra, la
+desmotivación, el deterioro del rendimiento, el clima laboral negativo, entre otros (Res.
+2764/2022 Ministerio de la Protección Social).
+
+Factor De Riesgo Psicosocial: Condición o condiciones del individuo, del medio extra
+laboral o del medio laboral, que, bajo determinadas condiciones de intensidad y tiempo de
+exposición generan efectos negativos en el colaborador o colaboradores, en la organización
+y en los grupos, y por último producen estrés.
+
+Factor Protector Psicosocial: Condiciones de trabajo que promueven la salud y el
+bienestar del colaborador.
+
+Factores Extralaborales: Aspectos relacionados con la situación socio-económica y
+educativa del grupo familiar, efecto del trabajo en el ámbito familiar y social, y situación
+política, económica y social del país.
+
+Factores Individuales: Aspectos relacionados con las características individuales del
+colaborador, como: características socio demográficas, de personalidad y aspectos que
+hacen referencia a estilos de afrontamiento.
+
+Factores Intralaborales: Aspectos relacionados con el medio ambiente de trabajo (lugar),
+la tarea (el quehacer cotidiano) y la organización (estructura y políticas).
+
+Patologías Derivadas Del Estrés: Aquellas en que las reacciones de estrés, bien sea por su
+persistencia o por su intensidad, activan el mecanismo fisiopatológico de una enfermedad.
+
+Epidemiología: Estudio de la distribución de la frecuencia de eventos o enfermedades y
+
+fenómenos de salud en diferentes grupos sociales y de los factores que determinan su
+ocurrencia.
+
+Vigilancia epidemiológica: Es un procedimiento que permite hacer seguimiento a los
+factores psicosociales y sus efectos, para conocer su distribución en la población y las
+variables que influyen en su presentación, bien sea porque intensifiquen o debiliten la
+manifestación del fenómeno.`;
+
+export interface IntroduccionData {
+  empresa: string;
+  total: number;
+  formaA: number;
+  formaB: number;
+  ciudad: string;
+}
+
+export function buildIntroduccion({
+  empresa,
+  total,
+  formaA,
+  formaB,
+  ciudad,
+}: IntroduccionData): string {
+  return template
+    .replace("[EMPRESA]", empresa)
+    .replace("[TOTAL]", String(total))
+    .replace("[FORMA_A]", String(formaA))
+    .replace("[FORMA_B]", String(formaB))
+    .replace("[CIUDAD]", ciudad);
+}


### PR DESCRIPTION
## Summary
- Genera texto de introducción con valores dinámicos para empresa, encuestas y ciudad
- Muestra la introducción personalizada en la pestaña de informes
- Calcula y envía automáticamente los datos de la empresa seleccionada al informe

## Testing
- `npm test` (falla: Missing script "test")
- `npx eslint src/report/introduccion.ts src/components/dashboard/InformeTabs.tsx src/components/DashboardResultados.tsx` (errores por `any` preexistentes en DashboardResultados.tsx)


------
https://chatgpt.com/codex/tasks/task_e_6898ca314ccc83319e86dc198d70515c