### PR TITLE
Add responsive risk category accordion in Metodología tab

### DIFF
--- a/src/components/dashboard/Metodologia.tsx
+++ b/src/components/dashboard/Metodologia.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import RiskAccordion from "./RiskAccordion";
 
 function ZoomableImage({ src, alt }: { src: string; alt: string }) {
   const [open, setOpen] = useState(false);
@@ -162,6 +163,7 @@ export default function Metodologia() {
       <div className="flex justify-center">
         <ZoomableImage src={fromPublic("FIGURA 2.png")} alt="FIGURA 2" />
       </div>
+      <RiskAccordion />
     </div>
   );
 }

--- a/src/components/dashboard/RiskAccordion.tsx
+++ b/src/components/dashboard/RiskAccordion.tsx
@@ -1,0 +1,84 @@
+import { useState } from "react";
+
+interface Category {
+  name: string;
+  description: string;
+  bgColor: string;
+  textColor: string;
+}
+
+const categories: Category[] = [
+  {
+    name: "Sin Riesgo",
+    description:
+      "Ausencia de riesgo o riesgo tan bajo que no amerita desarrollar actividades de intervención. Las dimensiones y dominios que se encuentren bajo esta categoría serán objeto de acciones o programas de promoción.",
+    bgColor: "bg-[#4CAF50]",
+    textColor: "text-white",
+  },
+  {
+    name: "Riesgo bajo",
+    description:
+      "No se espera que los factores psicosociales que obtengan puntuaciones de este nivel estén relacionados con síntomas o respuestas de estrés significativas. Las dimensiones y dominios que se encuentren bajo esta categoría serán objeto de acciones o programas de intervención, a fin de mantenerlos en los niveles de riesgo más bajos posibles.",
+    bgColor: "bg-[#8BC34A]",
+    textColor: "text-white",
+  },
+  {
+    name: "Riesgo medio",
+    description:
+      "Nivel de riesgo en el que se esperaría una respuesta de estrés moderada. Las dimensiones y dominios que se encuentren bajo esta categoría ameritan observación y acciones sistemáticas de intervención para prevenir efectos perjudiciales en la salud.",
+    bgColor: "bg-[#FFEB3B]",
+    textColor: "text-black",
+  },
+  {
+    name: "Riesgo alto",
+    description:
+      "Nivel de riesgo que tiene una importante posibilidad de asociación con respuestas de estrés alto y, por tanto, las dimensiones y dominios que se encuentren bajo esta categoría requieren intervención en el marco de un sistema de vigilancia epidemiológica.",
+    bgColor: "bg-[#F44336]",
+    textColor: "text-white",
+  },
+  {
+    name: "Riesgo muy alto",
+    description:
+      "Nivel de riesgo con amplia posibilidad de asociarse a respuestas muy altas de estrés. Por consiguiente, las dimensiones y dominios que se encuentren bajo esta categoría requieren intervención inmediata en el marco de un sistema de vigilancia epidemiológica.",
+    bgColor: "bg-[#B71C1C]",
+    textColor: "text-white",
+  },
+];
+
+export default function RiskAccordion() {
+  const [openIndex, setOpenIndex] = useState<number | null>(null);
+
+  const handleToggle = (index: number) => {
+    setOpenIndex((prev) => (prev === index ? null : index));
+  };
+
+  return (
+    <div className="w-full space-y-2">
+      {categories.map((cat, index) => (
+        <div key={cat.name} className="w-full">
+          <button
+            type="button"
+            className={`${cat.bgColor} ${cat.textColor} w-full text-left px-4 py-3 font-bold uppercase`}
+            onClick={() => handleToggle(index)}
+            aria-expanded={openIndex === index}
+            aria-controls={`panel-${index}`}
+            id={`accordion-${index}`}
+          >
+            {cat.name}
+          </button>
+          <div
+            id={`panel-${index}`}
+            role="region"
+            aria-labelledby={`accordion-${index}`}
+            className={`overflow-hidden transition-[max-height] duration-300 ease-in-out ${
+              openIndex === index ? "max-h-screen" : "max-h-0"
+            }`}
+          >
+            <div className="bg-white text-[#313B4A] px-4 py-3">{cat.description}</div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add `RiskAccordion` component with five risk categories and smooth expand/collapse animation
- display risk category accordion after existing images in the Metodología subtab

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 27 problems in unrelated files)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a97fb0b8c8331be4a4d217b665ab1