### PR TITLE
Expand methodology figures to match FIGURA 3 size

### DIFF
--- a/src/components/dashboard/Metodologia.tsx
+++ b/src/components/dashboard/Metodologia.tsx
@@ -166,10 +166,18 @@ export default function Metodologia() {
         </li>
       </ol>
       <div className="flex justify-center">
-        <ZoomableImage src={fromPublic("FIGURA 1.png")} alt="FIGURA 1" />
+        <ZoomableImage
+          src={fromPublic("FIGURA 1.png")}
+          alt="FIGURA 1"
+          className="w-full max-w-3xl"
+        />
       </div>
       <div className="flex justify-center">
-        <ZoomableImage src={fromPublic("FIGURA 2.png")} alt="FIGURA 2" />
+        <ZoomableImage
+          src={fromPublic("FIGURA 2.png")}
+          alt="FIGURA 2"
+          className="w-full max-w-3xl"
+        />
       </div>
       <RiskAccordion />
       <p>


### PR DESCRIPTION
## Summary
- Enlarge FIGURA 1 and FIGURA 2 images in Metodología subtab to match FIGURA 3 by applying consistent width constraints.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 27 problems in unrelated files)*
- `npx eslint src/components/dashboard/Metodologia.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689aa39497748331bcb6726b3c548815