### PR TITLE
Add sociodemographic recommendations

### DIFF
--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -32,6 +32,7 @@ import type { ReportOptions } from "@/types/report";
 import { recomendacionesPorResultados, conclusionesSinteticas } from "@/utils/recomendaciones";
 import { buildNarrativaContext } from "@/utils/narrativeMapper";
 import { getNarrativaSociodemo } from "@/services/narrativa";
+import { getRecomendacionSociodemo } from "@/services/recomendacionSociodemo";
 
 const nivelesRiesgo = [
   "Riesgo muy bajo",
@@ -758,6 +759,7 @@ export default function DashboardResultados({
 
   const narrativaCtx = buildNarrativaContext(reportPayload);
   const narrativaSociodemo = getNarrativaSociodemo(narrativaCtx);
+  const recomendacionesSociodemo = getRecomendacionSociodemo(reportPayload.sociodemo);
 
   const empresaId = reportPayload.empresa?.id || "empresa-actual";
 
@@ -1251,6 +1253,7 @@ export default function DashboardResultados({
                   tabClass={tabPill}
                   introduccionData={introData}
                   narrativaSociodemo={narrativaSociodemo}
+                  recomendacionesSociodemo={recomendacionesSociodemo}
                 />
             </section>
           </div>
@@ -1309,6 +1312,7 @@ export default function DashboardResultados({
                 conclusiones={conclusiones}
                 options={reportOptions}
                 narrativaSociodemo={narrativaSociodemo}
+                recomendacionesSociodemo={recomendacionesSociodemo}
               />
             </div>
           )}

--- a/src/components/ReportePDF.tsx
+++ b/src/components/ReportePDF.tsx
@@ -27,6 +27,7 @@ type Props = {
   conclusiones: string;
   options?: ReportOptions;
   narrativaSociodemo?: string;
+  recomendacionesSociodemo?: string;
 };
 
 const ReportePDF = forwardRef<HTMLDivElement, Props>(
@@ -41,6 +42,7 @@ const ReportePDF = forwardRef<HTMLDivElement, Props>(
       conclusiones,
       options,
       narrativaSociodemo,
+      recomendacionesSociodemo,
     },
     ref
   ) => {
@@ -166,6 +168,7 @@ const ReportePDF = forwardRef<HTMLDivElement, Props>(
             <section className="p-10">
               <Title>Sociodemografía de la Muestra</Title>
               {narrativaSociodemo && <p className="mt-4 text-justify">{narrativaSociodemo}</p>}
+              {recomendacionesSociodemo && <p className="mt-4 text-justify">{recomendacionesSociodemo}</p>}
               <div className="mt-6">{tablas.sociodemo}</div>
             </section>
             <div className="page-break"></div>

--- a/src/components/dashboard/InformeTabs.tsx
+++ b/src/components/dashboard/InformeTabs.tsx
@@ -11,12 +11,14 @@ interface Props {
   tabClass: string;
   introduccionData: IntroduccionData;
   narrativaSociodemo?: string;
+  recomendacionesSociodemo?: string;
 }
 
 export default function InformeTabs({
   tabClass,
   introduccionData,
   narrativaSociodemo,
+  recomendacionesSociodemo,
 }: Props) {
   const [value, setValue] = useState("introduccion");
   const intro = buildIntroduccion(introduccionData);
@@ -57,6 +59,7 @@ export default function InformeTabs({
           <div className="text-[#313B4A] text-justify font-montserrat text-base leading-relaxed space-y-4">
             <h3 className="text-lg font-semibold">Descripción sociodemográfica</h3>
             <p>{narrativaSociodemo}</p>
+            {recomendacionesSociodemo && <p>{recomendacionesSociodemo}</p>}
           </div>
         )}
       </TabsContent>

--- a/src/services/recomendacionSociodemo.ts
+++ b/src/services/recomendacionSociodemo.ts
@@ -1,0 +1,61 @@
+import { Sociodemo } from "@/types/report";
+
+/**
+ * Genera texto de recomendaciones laborales a partir de datos sociodemográficos.
+ */
+export function getRecomendacionSociodemo(s: Sociodemo): string {
+  const base =
+    "Se puede evidenciar que la empresa presenta una población estable que cumple con procesos y procedimientos normativos, sin embargo, se recomienda revisar lo siguiente: ";
+  const recomendaciones: string[] = [];
+
+  // Vivienda: porcentaje de viviendas arrendadas
+  const vivienda = s.vivienda || {};
+  const totalVivienda = Object.values(vivienda).reduce((a, b) => a + b, 0);
+  const arrendada = Object.entries(vivienda)
+    .filter(([k]) => k.toLowerCase().includes("arrend"))
+    .reduce((sum, [, c]) => sum + c, 0);
+  if (totalVivienda && arrendada / totalVivienda > 0.5) {
+    recomendaciones.push(
+      "implementar o fortalecer programas de apoyo para adquisición de vivienda propia mediante beneficios de la caja de compensación familiar."
+    );
+  }
+
+  // Promedio de horas diarias trabajadas
+  const horas = s.horasDiarias || {};
+  let horasTotal = 0;
+  let personasHoras = 0;
+  Object.entries(horas).forEach(([k, c]) => {
+    const num = parseFloat(k.replace(",", "."));
+    if (!isNaN(num)) {
+      horasTotal += num * c;
+      personasHoras += c;
+    }
+  });
+  const promedioHoras = personasHoras ? horasTotal / personasHoras : 0;
+  if (promedioHoras > 8.8) {
+    recomendaciones.push(
+      "ajustar la jornada laboral para cumplir con la Ley 2101 de 2021 sobre reducción progresiva de horas laborales."
+    );
+  }
+
+  // Tipos de contrato temporales o no definidos
+  const contratos = s.tipoContrato || {};
+  const totalContratos = Object.values(contratos).reduce((a, b) => a + b, 0);
+  const temporales = Object.entries(contratos)
+    .filter(([k]) => {
+      const l = k.toLowerCase();
+      const esTemporal = l.includes("temporal");
+      const esMenorAno =
+        l.includes("menos") || l.includes("<") || (l.includes("1") && l.includes("año"));
+      const noClasificado = !l.includes("fijo") && !l.includes("indef");
+      return esTemporal || esMenorAno || noClasificado;
+    })
+    .reduce((sum, [, c]) => sum + c, 0);
+  if (totalContratos && temporales / totalContratos > 0.5) {
+    recomendaciones.push(
+      "revisar y optimizar el sistema de contratación para fomentar la estabilidad laboral."
+    );
+  }
+
+  return recomendaciones.length ? base + recomendaciones.join("; ") : base;
+}


### PR DESCRIPTION
## Summary
- generate sociodemographic recommendation text based on housing, work hours and contract data
- display generated text in the "Resultados" report tab and PDF

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 27 problems)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ab2c6e6f88331a6de5f90d227e0c3