### PR TITLE
refactor: modularize survey flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,408 +1,140 @@
 import { useState, useEffect } from "react";
-import {
-  collection,
-  addDoc,
-  updateDoc,
-  deleteDoc,
-  getDocs,
-  doc,
-} from "firebase/firestore";
-import { db } from "./firebaseConfig";
-import Consentimiento from "./components/Consentimiento";
-import FormSelector from "./components/FormSelector";
-import FichaDatosGenerales from "./components/FichaDatosGenerales";
-import BloquesDePreguntas from "./components/BloquesDePreguntas";
-import DashboardResultados from "./components/DashboardResultados";
-import Login from "./components/Login";
+import RhomboidBackground from "./components/RhomboidBackground";
 import HomePage from "./components/HomePage";
 import PoliticaPrivacidad from "./components/PoliticaPrivacidad";
 import TerminosCondiciones from "./components/TerminosCondiciones";
-import RhomboidBackground from "./components/RhomboidBackground";
-import {
-  CredencialEmpresa,
-  FichaDatosGenerales as FichaDatos,
-  SurveyResponses,
-  IntralaboralResultado,
-  ExtralaboralResultado,
-  EstresResultado,
-  GlobalResultado,
-} from "./types";
-import {
-  bloquesFormaA,
-  bloquesFormaB,
-  preguntasA,
-  preguntasB,
-  preguntasExtralaboral,
-  preguntasEstres,
-  bloqueExtralaboral,
-  bloqueEstres
-} from "./data/preguntas";
-import { calcularEstres } from "./utils/calcularEstres";
-import { calcularExtralaboral } from "./utils/calcularExtralaboral";
-import { calcularFormaA } from "./utils/calcularFormaA";
-import { calcularFormaB } from "./utils/calcularFormaB";
-import { calcularGlobalAExtrala, calcularGlobalBExtrala } from "./utils/calcularGlobalA";
-import removeUndefined from "./utils/removeUndefined";
-import { demoCredencialesConst } from "./data/demoCredenciales";
+import Login from "./components/Login";
+import DashboardResultados from "./components/DashboardResultados";
+import Consentimiento from "./components/Consentimiento";
+import SelectorScreen from "./components/SelectorScreen";
+import FichaScreen from "./components/FichaScreen";
+import BloquesScreen from "./components/BloquesScreen";
+import ExtralaboralScreen from "./components/ExtralaboralScreen";
+import EstresScreen from "./components/EstresScreen";
+import FinalScreen from "./components/FinalScreen";
+import useCredenciales from "./hooks/useCredenciales";
+import useSurveySteps from "./hooks/useSurveySteps";
+import { guardarResultados } from "./services/resultService";
 
 type RolUsuario = "ninguno" | "psicologa" | "dueno";
 
 export default function App() {
-  const [step, setStep] = useState<
-    "inicio" |
-    "consent" |
-    "selector" |
-    "ficha" |
-    "bloques" |
-    "extralaboral" |
-    "estres" |
-    "final" |
-    "dashboard" |
-    "login" |
-    "privacy" |
-    "terms"
-  >("inicio");
+  const {
+    credenciales,
+    empresasIniciales,
+    agregarEmpresa,
+    eliminarEmpresa,
+    editarEmpresa,
+  } = useCredenciales();
 
-  const [formType, setFormType] = useState<"A" | "B" | null>(null);
-  const [ficha, setFicha] = useState<FichaDatos | null>(null);
+  const {
+    step,
+    setStep,
+    formType,
+    seleccionarFormulario,
+    guardarFicha,
+    completarBloques,
+    completarExtralaboral,
+    completarEstres,
+    ficha,
+    respuestas,
+    resultadoEstres,
+    resultadoExtralaboral,
+  } = useSurveySteps();
 
-  const demoCredenciales: (CredencialEmpresa & { rol: string })[] = JSON.parse(
-    import.meta.env.VITE_DEMO_CREDENTIALS ||
-      JSON.stringify(demoCredencialesConst)
-  );
-
-  const [credenciales, setCredenciales] = useState<
-    (CredencialEmpresa & { rol: string; id?: string })[]
-  >(demoCredenciales);
-  const [empresasIniciales, setEmpresasIniciales] = useState<string[]>(() =>
-    demoCredenciales
-      .filter((c) => c.rol === "dueno" && c.empresa)
-      .map((c) => c.empresa!)
-  );
-
-  useEffect(() => {
-    const cargarCreds = async () => {
-      const snap = await getDocs(collection(db, "credencialesCogent"));
-      const extras = snap.docs.map((d) => ({
-        id: d.id,
-        ...(d.data() as CredencialEmpresa & { rol: string }),
-      }));
-      setCredenciales((prev) => {
-        const merged = [...prev];
-        extras.forEach((c) => {
-          if (!merged.some((m) => m.usuario === c.usuario)) {
-            merged.push(c);
-          }
-        });
-        return merged;
-      });
-    };
-    cargarCreds();
-  }, []);
-
-  useEffect(() => {
-    const empresas = Array.from(
-      new Set(
-        credenciales
-          .filter((c) => c.rol === "dueno" && c.empresa)
-          .map((c) => c.empresa as string)
-      )
-    );
-    setEmpresasIniciales(empresas);
-  }, [credenciales]);
-
-  // Para guardar todas las respuestas por sección
-  const [respuestas, setRespuestas] = useState<SurveyResponses>({});
-  // Para guardar los resultados de cada test
-  const [resultadoEstres, setResultadoEstres] = useState<EstresResultado | null>(null);
-  const [resultadoExtralaboral, setResultadoExtralaboral] = useState<ExtralaboralResultado | null>(null);
-  const [resultadoFormaA, setResultadoFormaA] = useState<IntralaboralResultado | null>(null);
-  const [resultadoFormaB, setResultadoFormaB] = useState<IntralaboralResultado | null>(null);
-  const [resultadoGlobalAExtra, setResultadoGlobalAExtra] = useState<GlobalResultado | null>(null);
-  const [resultadoGlobalBExtra, setResultadoGlobalBExtra] = useState<GlobalResultado | null>(null);
-
-  // Manejo de login (muy básico)
   const [rol, setRol] = useState<RolUsuario>("ninguno");
   const [empresaActual, setEmpresaActual] = useState<string | null>(null);
 
-  const agregarEmpresa = async (
-    nombre: string,
-    usuario: string,
-    password: string
-  ): Promise<boolean> => {
-    try {
-      const docRef = await addDoc(collection(db, "credencialesCogent"), {
-        usuario,
-        password,
-        rol: "dueno",
-        empresa: nombre,
-      });
-      setCredenciales((prev) => [
-        ...prev,
-        { id: docRef.id, usuario, password, rol: "dueno", empresa: nombre },
-      ]);
-      return true;
-    } catch (err) {
-      console.error("Error al agregar empresa", err);
-      alert("No se pudo agregar la empresa");
-      return false;
-    }
-  };
-
-  const eliminarEmpresa = async (usuario: string): Promise<boolean> => {
-    const cred = credenciales.find((c) => c.usuario === usuario);
-    if (!cred?.id) return false;
-    try {
-      await deleteDoc(doc(db, "credencialesCogent", cred.id));
-      setCredenciales((prev) => prev.filter((c) => c.usuario !== usuario));
-      return true;
-    } catch (err) {
-      console.error("Error al eliminar empresa", err);
-      alert("No se pudo eliminar la empresa");
-      return false;
-    }
-  };
-
-  const editarEmpresa = async (
-    originalUsuario: string,
-    nombre: string,
-    usuario: string,
-    password: string
-  ): Promise<boolean> => {
-    const cred = credenciales.find((c) => c.usuario === originalUsuario);
-    if (!cred?.id) return false;
-    try {
-      await updateDoc(doc(db, "credencialesCogent", cred.id), {
-        usuario,
-        password,
-        empresa: nombre,
-      });
-      setCredenciales((prev) =>
-        prev.map((c) =>
-          c.usuario === originalUsuario
-            ? { ...c, usuario, password, empresa: nombre }
-            : c
-        )
-      );
-      return true;
-    } catch (err) {
-      console.error("Error al editar empresa", err);
-      alert("No se pudo editar la empresa");
-      return false;
-    }
-  };
-
-  // Cuando finaliza la encuesta (luego del bloque de estrés)
   useEffect(() => {
-    const guardar = async () => {
-      if (step === "final") {
-        // Calcula resultados por formulario
-        let resultadoForma = null;
-        let resultadoGlobal = null;
-      if (formType === "A" && respuestas.bloques) {
-        const arr = Array.from({ length: preguntasA.length }, (_, i) =>
-          respuestas.bloques?.[i] ?? ""
-        );
-        resultadoForma = calcularFormaA(arr);
-        setResultadoFormaA(resultadoForma);
-        if (resultadoExtralaboral) {
-          resultadoGlobal = calcularGlobalAExtrala(
-            resultadoForma?.total?.suma ?? 0,
-            resultadoExtralaboral.puntajeBrutoTotal ?? 0
-          );
-          setResultadoGlobalAExtra(resultadoGlobal);
-        }
-      } else if (formType === "B" && respuestas.bloques) {
-        const arr = Array.from({ length: preguntasB.length }, (_, i) =>
-          respuestas.bloques?.[i] ?? ""
-        );
-        resultadoForma = calcularFormaB(arr);
-        setResultadoFormaB(resultadoForma);
-        if (resultadoExtralaboral) {
-          resultadoGlobal = calcularGlobalBExtrala(
-            resultadoForma?.total?.suma ?? 0,
-            resultadoExtralaboral.puntajeBrutoTotal ?? 0
-          );
-          setResultadoGlobalBExtra(resultadoGlobal);
-        }
-      }
-
-        // Guarda todo lo que quieras conservar
-        const data: any = {
-          ficha,
-          respuestas,
-          resultadoEstres,
-          resultadoExtralaboral,
-          tipo: formType,
-          fecha: ficha?.fecha || new Date().toISOString(),
-        };
-        if (formType === "A") {
-          data.resultadoFormaA = resultadoForma;
-          data.resultadoGlobalAExtralaboral = resultadoGlobal;
-        }
-        if (formType === "B") {
-          data.resultadoFormaB = resultadoForma;
-          data.resultadoGlobalBExtralaboral = resultadoGlobal;
-        }
-        // Limpia datos y guarda en Firestore
-        const cleanData = removeUndefined(data);
-        try {
-          await addDoc(collection(db, "resultadosCogent"), cleanData);
-        } catch (err) {
-          console.error("Error al guardar resultados", err);
-          alert("No se pudieron guardar los resultados");
-        }
-      }
-    };
-    guardar();
+    if (step === "final") {
+      guardarResultados({
+        ficha,
+        respuestas,
+        resultadoEstres,
+        resultadoExtralaboral,
+        formType,
+      });
+    }
   }, [step, ficha, respuestas, resultadoEstres, resultadoExtralaboral, formType]);
 
-  let content: React.ReactNode;
-
-  if (step === "inicio") {
-    content = (
-      <HomePage
-        onStartSurvey={() => setStep("consent")}
-        onViewResults={() => setStep("login")}
-        onPrivacy={() => setStep("privacy")}
-        onTerms={() => setStep("terms")}
-      />
-    );
-  } else if (step === "privacy") {
-    content = <PoliticaPrivacidad onBack={() => setStep("inicio")} />;
-  } else if (step === "terms") {
-    content = <TerminosCondiciones onBack={() => setStep("inicio")} />;
-  } else if (step === "login") {
-    content = (
-      <Login
-        usuarios={credenciales}
-        onLogin={(nuevoRol, empresa) => {
-          setRol(nuevoRol as RolUsuario);
-          setEmpresaActual(empresa || null);
-          setStep("dashboard");
-        }}
-        onCancel={() => setStep("inicio")}
-      />
-    );
-  } else if (step === "dashboard") {
-    content = (
-      <DashboardResultados
-        rol={rol as "psicologa" | "dueno"}
-        empresaNombre={empresaActual || undefined}
-        empresaFiltro={rol === "dueno" ? empresaActual || undefined : undefined}
-        soloGenerales={rol === "dueno"}
-        credenciales={credenciales.filter((c) => c.rol === "dueno")}
-        onAgregarEmpresa={agregarEmpresa}
-        onEliminarEmpresa={eliminarEmpresa}
-        onEditarEmpresa={editarEmpresa}
-        onBack={() => setStep("inicio")}
-      />
-    );
-  } else {
-    content = (
-      <div className="min-h-screen flex flex-col items-center justify-center bg-[var(--background-main)]">
-        {step === "consent" && (
-          <Consentimiento onAceptar={() => setStep("selector")} />
-        )}
-        {step === "selector" && (
-          <FormSelector
-            onSelect={(form) => {
-              setFormType(form);
-              setStep("ficha");
-            }}
+  const renderContent = () => {
+    switch (step) {
+      case "inicio":
+        return (
+          <HomePage
+            onStartSurvey={() => setStep("consent")}
+            onViewResults={() => setStep("login")}
+            onPrivacy={() => setStep("privacy")}
+            onTerms={() => setStep("terms")}
           />
-        )}
-        {step === "ficha" && (
-          <FichaDatosGenerales
+        );
+      case "privacy":
+        return <PoliticaPrivacidad onBack={() => setStep("inicio")} />;
+      case "terms":
+        return <TerminosCondiciones onBack={() => setStep("inicio")} />;
+      case "login":
+        return (
+          <Login
+            usuarios={credenciales}
+            onLogin={(nuevoRol, empresa) => {
+              setRol(nuevoRol as RolUsuario);
+              setEmpresaActual(empresa || null);
+              setStep("dashboard");
+            }}
+            onCancel={() => setStep("inicio")}
+          />
+        );
+      case "dashboard":
+        return (
+          <DashboardResultados
+            rol={rol as "psicologa" | "dueno"}
+            empresaNombre={empresaActual || undefined}
+            empresaFiltro={
+              rol === "dueno" ? empresaActual || undefined : undefined
+            }
+            soloGenerales={rol === "dueno"}
+            credenciales={credenciales.filter((c) => c.rol === "dueno")}
+            onAgregarEmpresa={agregarEmpresa}
+            onEliminarEmpresa={eliminarEmpresa}
+            onEditarEmpresa={editarEmpresa}
+            onBack={() => setStep("inicio")}
+          />
+        );
+      case "consent":
+        return <Consentimiento onAceptar={() => setStep("selector")} />;
+      case "selector":
+        return <SelectorScreen onSelect={seleccionarFormulario} />;
+      case "ficha":
+        return (
+          <FichaScreen
             empresasIniciales={empresasIniciales}
-            onGuardar={(datos) => {
-              setFicha(datos);
-              setStep("bloques");
-            }}
+            onGuardar={guardarFicha}
           />
-        )}
-        {step === "bloques" && (
-          <BloquesDePreguntas
-            bloques={formType === "A" ? bloquesFormaA : bloquesFormaB}
-            preguntas={formType === "A" ? preguntasA : preguntasB}
-            onFinish={(respuestasBloques) => {
-              const ordered = Array.from(
-                { length: formType === "A" ? preguntasA.length : preguntasB.length },
-                (_, i) => respuestasBloques[i] ?? ""
-              );
-              setRespuestas((prev) => ({ ...prev, bloques: ordered }));
-              setStep("extralaboral");
-            }}
+        );
+      case "bloques":
+        return (
+          <BloquesScreen
+            formType={formType as "A" | "B"}
+            onFinish={completarBloques}
           />
-        )}
-        {step === "extralaboral" && (
-          <BloquesDePreguntas
-            bloques={bloqueExtralaboral}
-            preguntas={preguntasExtralaboral}
-            onFinish={(respuestasExtra) => {
-              const ordered = Array.from(
-                { length: preguntasExtralaboral.length },
-                (_, i) => respuestasExtra[i] ?? ""
-              );
-              const resultado = calcularExtralaboral(
-                ordered,
-                formType as "A" | "B"
-              );
-              setResultadoExtralaboral(resultado);
-              setRespuestas((prev) => ({
-                ...prev,
-                extralaboral: ordered,
-                resultadoExtralaboral: resultado
-              }));
-              setStep("estres");
-            }}
-          />
-        )}
-        {step === "estres" && (
-          <BloquesDePreguntas
-            bloques={bloqueEstres}
-            preguntas={preguntasEstres}
-            onFinish={(respuestasEstres) => {
-              const ordered = Array.from(
-                { length: preguntasEstres.length },
-                (_, i) => respuestasEstres[i] ?? ""
-              );
-              const resultado = calcularEstres(
-                ordered,
-                formType as "A" | "B"
-              );
-              setResultadoEstres(resultado);
-              setRespuestas((prev) => ({
-                ...prev,
-                estres: ordered,
-                resultadoEstres: resultado
-              }));
-              setStep("final");
-            }}
-          />
-        )}
-        {step === "final" && (
-          <div className="p-8 bg-white rounded-xl shadow-md text-[var(--text-main)] font-bold text-2xl flex flex-col items-center gap-4">
-            <div>
-              ¡Encuesta completada!<br />
-              Gracias por tu participación.
-            </div>
-            <button
-              className="bg-primary-main text-white px-6 py-2 rounded-lg shadow hover:bg-primary-light text-base"
-              onClick={() => setStep("inicio")}
-            >
-              Volver al inicio
-            </button>
-          </div>
-        )}
-      </div>
-    );
-  }
+        );
+      case "extralaboral":
+        return <ExtralaboralScreen onFinish={completarExtralaboral} />;
+      case "estres":
+        return <EstresScreen onFinish={completarEstres} />;
+      case "final":
+        return <FinalScreen onRestart={() => setStep("inicio")} />;
+      default:
+        return null;
+    }
+  };
 
   return (
     <>
       <RhomboidBackground />
-      {content}
+      <div className="min-h-screen flex flex-col items-center justify-center bg-[var(--background-main)]">
+        {renderContent()}
+      </div>
     </>
   );
 }

--- a/src/components/BloquesScreen.tsx
+++ b/src/components/BloquesScreen.tsx
@@ -1,0 +1,22 @@
+import BloquesDePreguntas from "./BloquesDePreguntas";
+import {
+  bloquesFormaA,
+  bloquesFormaB,
+  preguntasA,
+  preguntasB,
+} from "../data/preguntas";
+
+interface Props {
+  formType: "A" | "B";
+  onFinish: (respuestas: string[]) => void;
+}
+
+export default function BloquesScreen({ formType, onFinish }: Props) {
+  return (
+    <BloquesDePreguntas
+      bloques={formType === "A" ? bloquesFormaA : bloquesFormaB}
+      preguntas={formType === "A" ? preguntasA : preguntasB}
+      onFinish={onFinish}
+    />
+  );
+}

--- a/src/components/EstresScreen.tsx
+++ b/src/components/EstresScreen.tsx
@@ -1,0 +1,16 @@
+import BloquesDePreguntas from "./BloquesDePreguntas";
+import { bloqueEstres, preguntasEstres } from "../data/preguntas";
+
+interface Props {
+  onFinish: (respuestas: string[]) => void;
+}
+
+export default function EstresScreen({ onFinish }: Props) {
+  return (
+    <BloquesDePreguntas
+      bloques={bloqueEstres}
+      preguntas={preguntasEstres}
+      onFinish={onFinish}
+    />
+  );
+}

--- a/src/components/ExtralaboralScreen.tsx
+++ b/src/components/ExtralaboralScreen.tsx
@@ -1,0 +1,16 @@
+import BloquesDePreguntas from "./BloquesDePreguntas";
+import { bloqueExtralaboral, preguntasExtralaboral } from "../data/preguntas";
+
+interface Props {
+  onFinish: (respuestas: string[]) => void;
+}
+
+export default function ExtralaboralScreen({ onFinish }: Props) {
+  return (
+    <BloquesDePreguntas
+      bloques={bloqueExtralaboral}
+      preguntas={preguntasExtralaboral}
+      onFinish={onFinish}
+    />
+  );
+}

--- a/src/components/FichaScreen.tsx
+++ b/src/components/FichaScreen.tsx
@@ -1,0 +1,16 @@
+import FichaDatosGenerales from "./FichaDatosGenerales";
+import { FichaDatosGenerales as FichaDatos } from "../types";
+
+interface Props {
+  empresasIniciales: string[];
+  onGuardar: (datos: FichaDatos) => void;
+}
+
+export default function FichaScreen({ empresasIniciales, onGuardar }: Props) {
+  return (
+    <FichaDatosGenerales
+      empresasIniciales={empresasIniciales}
+      onGuardar={onGuardar}
+    />
+  );
+}

--- a/src/components/FinalScreen.tsx
+++ b/src/components/FinalScreen.tsx
@@ -1,0 +1,21 @@
+interface Props {
+  onRestart: () => void;
+}
+
+export default function FinalScreen({ onRestart }: Props) {
+  return (
+    <div className="p-8 bg-white rounded-xl shadow-md text-[var(--text-main)] font-bold text-2xl flex flex-col items-center gap-4">
+      <div>
+        ¡Encuesta completada!
+        <br />
+        Gracias por tu participación.
+      </div>
+      <button
+        className="bg-primary-main text-white px-6 py-2 rounded-lg shadow hover:bg-primary-light text-base"
+        onClick={onRestart}
+      >
+        Volver al inicio
+      </button>
+    </div>
+  );
+}

--- a/src/components/SelectorScreen.tsx
+++ b/src/components/SelectorScreen.tsx
@@ -1,0 +1,9 @@
+import FormSelector from "./FormSelector";
+
+interface Props {
+  onSelect: (form: "A" | "B") => void;
+}
+
+export default function SelectorScreen({ onSelect }: Props) {
+  return <FormSelector onSelect={onSelect} />;
+}

--- a/src/hooks/useCredenciales.ts
+++ b/src/hooks/useCredenciales.ts
@@ -1,0 +1,134 @@
+import { useState, useEffect } from "react";
+import {
+  collection,
+  addDoc,
+  updateDoc,
+  deleteDoc,
+  getDocs,
+  doc,
+} from "firebase/firestore";
+import { db } from "../firebaseConfig";
+import { CredencialEmpresa } from "../types";
+import { demoCredencialesConst } from "../data/demoCredenciales";
+
+export default function useCredenciales() {
+  const demoCredenciales: (CredencialEmpresa & { rol: string })[] = JSON.parse(
+    import.meta.env.VITE_DEMO_CREDENTIALS ||
+      JSON.stringify(demoCredencialesConst)
+  );
+
+  const [credenciales, setCredenciales] = useState<
+    (CredencialEmpresa & { rol: string; id?: string })[]
+  >(demoCredenciales);
+  const [empresasIniciales, setEmpresasIniciales] = useState<string[]>(() =>
+    demoCredenciales
+      .filter((c) => c.rol === "dueno" && c.empresa)
+      .map((c) => c.empresa!)
+  );
+
+  useEffect(() => {
+    const cargarCreds = async () => {
+      const snap = await getDocs(collection(db, "credencialesCogent"));
+      const extras = snap.docs.map((d) => ({
+        id: d.id,
+        ...(d.data() as CredencialEmpresa & { rol: string }),
+      }));
+      setCredenciales((prev) => {
+        const merged = [...prev];
+        extras.forEach((c) => {
+          if (!merged.some((m) => m.usuario === c.usuario)) {
+            merged.push(c);
+          }
+        });
+        return merged;
+      });
+    };
+    cargarCreds();
+  }, []);
+
+  useEffect(() => {
+    const empresas = Array.from(
+      new Set(
+        credenciales
+          .filter((c) => c.rol === "dueno" && c.empresa)
+          .map((c) => c.empresa as string)
+      )
+    );
+    setEmpresasIniciales(empresas);
+  }, [credenciales]);
+
+  const agregarEmpresa = async (
+    nombre: string,
+    usuario: string,
+    password: string
+  ): Promise<boolean> => {
+    try {
+      const docRef = await addDoc(collection(db, "credencialesCogent"), {
+        usuario,
+        password,
+        rol: "dueno",
+        empresa: nombre,
+      });
+      setCredenciales((prev) => [
+        ...prev,
+        { id: docRef.id, usuario, password, rol: "dueno", empresa: nombre },
+      ]);
+      return true;
+    } catch (err) {
+      console.error("Error al agregar empresa", err);
+      alert("No se pudo agregar la empresa");
+      return false;
+    }
+  };
+
+  const eliminarEmpresa = async (usuario: string): Promise<boolean> => {
+    const cred = credenciales.find((c) => c.usuario === usuario);
+    if (!cred?.id) return false;
+    try {
+      await deleteDoc(doc(db, "credencialesCogent", cred.id));
+      setCredenciales((prev) => prev.filter((c) => c.usuario !== usuario));
+      return true;
+    } catch (err) {
+      console.error("Error al eliminar empresa", err);
+      alert("No se pudo eliminar la empresa");
+      return false;
+    }
+  };
+
+  const editarEmpresa = async (
+    originalUsuario: string,
+    nombre: string,
+    usuario: string,
+    password: string
+  ): Promise<boolean> => {
+    const cred = credenciales.find((c) => c.usuario === originalUsuario);
+    if (!cred?.id) return false;
+    try {
+      await updateDoc(doc(db, "credencialesCogent", cred.id), {
+        usuario,
+        password,
+        empresa: nombre,
+      });
+      setCredenciales((prev) =>
+        prev.map((c) =>
+          c.usuario === originalUsuario
+            ? { ...c, usuario, password, empresa: nombre }
+            : c
+        )
+      );
+      return true;
+    } catch (err) {
+      console.error("Error al editar empresa", err);
+      alert("No se pudo editar la empresa");
+      return false;
+    }
+  };
+
+  return {
+    credenciales,
+    empresasIniciales,
+    agregarEmpresa,
+    eliminarEmpresa,
+    editarEmpresa,
+  };
+}

--- a/src/hooks/useSurveySteps.ts
+++ b/src/hooks/useSurveySteps.ts
@@ -1,0 +1,117 @@
+import { useState } from "react";
+import {
+  FichaDatosGenerales as FichaDatos,
+  SurveyResponses,
+  EstresResultado,
+  ExtralaboralResultado,
+} from "../types";
+import {
+  preguntasA,
+  preguntasB,
+  preguntasExtralaboral,
+  preguntasEstres,
+} from "../data/preguntas";
+import { calcularExtralaboral } from "../utils/calcularExtralaboral";
+import { calcularEstres } from "../utils/calcularEstres";
+
+type Step =
+  | "inicio"
+  | "consent"
+  | "selector"
+  | "ficha"
+  | "bloques"
+  | "extralaboral"
+  | "estres"
+  | "final"
+  | "dashboard"
+  | "login"
+  | "privacy"
+  | "terms";
+
+export default function useSurveySteps() {
+  const [step, setStep] = useState<Step>("inicio");
+  const [formType, setFormType] = useState<"A" | "B" | null>(null);
+  const [ficha, setFicha] = useState<FichaDatos | null>(null);
+  const [respuestas, setRespuestas] = useState<SurveyResponses>({});
+  const [resultadoEstres, setResultadoEstres] =
+    useState<EstresResultado | null>(null);
+  const [resultadoExtralaboral, setResultadoExtralaboral] =
+    useState<ExtralaboralResultado | null>(null);
+
+  const seleccionarFormulario = (form: "A" | "B") => {
+    setFormType(form);
+    setStep("ficha");
+  };
+
+  const guardarFicha = (datos: FichaDatos) => {
+    setFicha(datos);
+    setStep("bloques");
+  };
+
+  const completarBloques = (respuestasBloques: string[]) => {
+    const ordered = Array.from(
+      { length: formType === "A" ? preguntasA.length : preguntasB.length },
+      (_, i) => respuestasBloques[i] ?? ""
+    );
+    setRespuestas((prev) => ({ ...prev, bloques: ordered }));
+    setStep("extralaboral");
+  };
+
+  const completarExtralaboral = (respuestasExtra: string[]) => {
+    const ordered = Array.from(
+      { length: preguntasExtralaboral.length },
+      (_, i) => respuestasExtra[i] ?? ""
+    );
+    const resultado = calcularExtralaboral(
+      ordered,
+      formType as "A" | "B"
+    );
+    setResultadoExtralaboral(resultado);
+    setRespuestas((prev) => ({
+      ...prev,
+      extralaboral: ordered,
+      resultadoExtralaboral: resultado,
+    }));
+    setStep("estres");
+  };
+
+  const completarEstres = (respuestasEstres: string[]) => {
+    const ordered = Array.from(
+      { length: preguntasEstres.length },
+      (_, i) => respuestasEstres[i] ?? ""
+    );
+    const resultado = calcularEstres(ordered, formType as "A" | "B");
+    setResultadoEstres(resultado);
+    setRespuestas((prev) => ({
+      ...prev,
+      estres: ordered,
+      resultadoEstres: resultado,
+    }));
+    setStep("final");
+  };
+
+  const reiniciar = () => {
+    setStep("inicio");
+    setFormType(null);
+    setFicha(null);
+    setRespuestas({});
+    setResultadoEstres(null);
+    setResultadoExtralaboral(null);
+  };
+
+  return {
+    step,
+    setStep,
+    formType,
+    seleccionarFormulario,
+    guardarFicha,
+    completarBloques,
+    completarExtralaboral,
+    completarEstres,
+    reiniciar,
+    ficha,
+    respuestas,
+    resultadoEstres,
+    resultadoExtralaboral,
+  };
+}

--- a/src/services/resultService.ts
+++ b/src/services/resultService.ts
@@ -1,0 +1,91 @@
+import { collection, addDoc } from "firebase/firestore";
+import { db } from "../firebaseConfig";
+import {
+  FichaDatosGenerales as FichaDatos,
+  SurveyResponses,
+  EstresResultado,
+  ExtralaboralResultado,
+  IntralaboralResultado,
+  GlobalResultado,
+} from "../types";
+import { preguntasA, preguntasB } from "../data/preguntas";
+import { calcularFormaA } from "../utils/calcularFormaA";
+import { calcularFormaB } from "../utils/calcularFormaB";
+import {
+  calcularGlobalAExtrala,
+  calcularGlobalBExtrala,
+} from "../utils/calcularGlobalA";
+import removeUndefined from "../utils/removeUndefined";
+
+interface Params {
+  ficha: FichaDatos | null;
+  respuestas: SurveyResponses;
+  resultadoEstres: EstresResultado | null;
+  resultadoExtralaboral: ExtralaboralResultado | null;
+  formType: "A" | "B" | null;
+}
+
+export async function guardarResultados({
+  ficha,
+  respuestas,
+  resultadoEstres,
+  resultadoExtralaboral,
+  formType,
+}: Params) {
+  if (!formType) return;
+
+  let resultadoForma: IntralaboralResultado | null = null;
+  let resultadoGlobal: GlobalResultado | null = null;
+
+  if (formType === "A" && respuestas.bloques) {
+    const arr = Array.from({ length: preguntasA.length }, (_, i) =>
+      respuestas.bloques?.[i] ?? ""
+    );
+    resultadoForma = calcularFormaA(arr);
+    if (resultadoExtralaboral) {
+      resultadoGlobal = calcularGlobalAExtrala(
+        resultadoForma?.total?.suma ?? 0,
+        resultadoExtralaboral.puntajeBrutoTotal ?? 0
+      );
+    }
+  } else if (formType === "B" && respuestas.bloques) {
+    const arr = Array.from({ length: preguntasB.length }, (_, i) =>
+      respuestas.bloques?.[i] ?? ""
+    );
+    resultadoForma = calcularFormaB(arr);
+    if (resultadoExtralaboral) {
+      resultadoGlobal = calcularGlobalBExtrala(
+        resultadoForma?.total?.suma ?? 0,
+        resultadoExtralaboral.puntajeBrutoTotal ?? 0
+      );
+    }
+  }
+
+  const data: Record<string, unknown> = {
+    ficha,
+    respuestas,
+    resultadoEstres,
+    resultadoExtralaboral,
+    tipo: formType,
+    fecha: ficha?.fecha || new Date().toISOString(),
+  };
+
+  if (formType === "A") {
+    data.resultadoFormaA = resultadoForma;
+    data.resultadoGlobalAExtralaboral = resultadoGlobal;
+  }
+  if (formType === "B") {
+    data.resultadoFormaB = resultadoForma;
+    data.resultadoGlobalBExtralaboral = resultadoGlobal;
+  }
+
+  const cleanData = removeUndefined(data);
+  try {
+    await addDoc(collection(db, "resultadosCogent"), cleanData);
+  } catch (err) {
+    console.error("Error al guardar resultados", err);
+    alert("No se pudieron guardar los resultados");
+  }
+
+  return { resultadoForma, resultadoGlobal };
+}


### PR DESCRIPTION
## Summary
- add `useCredenciales` hook and `useSurveySteps` to manage state and credentials
- extract survey screens and result service, slimming down `App.tsx`
- implement `resultService` to calculate and persist results

## Testing
- `npm run lint` *(fails: Unexpected any, unused vars in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_689ab6126d9c833191b3423ff007778a