### PR TITLE
Add sociodemographic results table

### DIFF
--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -1254,6 +1254,7 @@ export default function DashboardResultados({
                   introduccionData={introData}
                   narrativaSociodemo={narrativaSociodemo}
                   recomendacionesSociodemo={recomendacionesSociodemo}
+                  payload={reportPayload}
                 />
             </section>
           </div>

--- a/src/components/TablaSociodemo.tsx
+++ b/src/components/TablaSociodemo.tsx
@@ -1,0 +1,110 @@
+import React from "react";
+import { ReportPayload, SociodemoDistribucion } from "@/types/report";
+
+interface Props {
+  payload: ReportPayload;
+  exportMode?: boolean;
+}
+
+interface GrupoDef {
+  key: keyof ReportPayload["sociodemo"];
+  titulo: string;
+}
+
+const grupos: GrupoDef[] = [
+  { key: "genero", titulo: "GÉNERO" },
+  { key: "estadoCivil", titulo: "ESTADO CIVIL" },
+  { key: "escolaridad", titulo: "GRADO DE ESCOLARIDAD" },
+  { key: "estrato", titulo: "ESTRATO S.E." },
+  { key: "vivienda", titulo: "TIPO DE VIVIENDA" },
+  { key: "personasACargo", titulo: "NÚMERO DE PERSONAS A CARGO" },
+  { key: "antiguedad", titulo: "ANTIGÜEDAD EN LA EMPRESA" },
+  { key: "tipoContrato", titulo: "TIPO DE CONTRATACIÓN" },
+  { key: "horasDiarias", titulo: "HORAS DE TRABAJO ESTABLECIDAS" },
+  { key: "salario", titulo: "TIPO DE SALARIO" },
+];
+
+const formatter = new Intl.NumberFormat("es-CO", {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+export default function TablaSociodemo({ payload, exportMode = false }: Props) {
+  const total = payload.muestra?.total || 0;
+
+  function filasDesde(dist?: SociodemoDistribucion) {
+    if (!dist) return [] as [string, number][];
+    const entries = Object.entries(dist).filter(([, c]) => c > 0);
+    return entries.sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+  }
+
+  return (
+    <div className="rounded-2xl shadow-sm bg-white p-4 md:p-6 font-montserrat text-[#172349]">
+      <div className="mb-4">
+        <h3 className="text-lg font-semibold">Ficha sociodemográfica</h3>
+        <p className="text-sm text-gray-500">N = {total}</p>
+      </div>
+      <div className="space-y-6">
+        {grupos.map(({ key, titulo }) => {
+          const filas = filasDesde(payload.sociodemo?.[key]);
+          if (filas.length === 0) return null;
+          return (
+            <div key={key}>
+              <div className="inline-block bg-blue-50 text-blue-700 text-xs font-semibold uppercase rounded-xl px-3 py-1 mb-2">
+                {titulo}
+              </div>
+              <table className="w-full text-sm">
+                <thead className="hidden lg:table-header-group text-gray-500">
+                  <tr className="border-b">
+                    <th className="text-left py-2">Detalle</th>
+                    <th className="text-right py-2">Nº Trabajadores</th>
+                    <th className="text-right py-2">%</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {filas.map(([label, count]) => {
+                    const percent = total > 0 ? (count / total) * 100 : 0;
+                    const porcentaje = formatter.format(percent);
+                    const rowClass = `border-b ${!exportMode ? "hover:bg-slate-50" : ""}`;
+                    return (
+                      <tr key={label} className={rowClass}>
+                        <td className="py-2">{label}</td>
+                        <td className="py-2 text-right align-top">
+                          <span className="hidden lg:inline">{total > 0 ? count : "—"}</span>
+                          <div className="lg:hidden flex flex-col items-end">
+                            <span>{total > 0 ? count : "—"}</span>
+                            <div className="flex items-center gap-2 mt-1">
+                              <span className="text-xs">{porcentaje}%</span>
+                              <div className="w-20 bg-blue-50 rounded-full h-1.5 overflow-hidden">
+                                <div
+                                  className="bg-blue-600 h-full"
+                                  style={{ width: `${percent}%` }}
+                                />
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                        <td className="hidden lg:table-cell py-2 text-right w-40">
+                          <div className="flex items-center justify-end gap-2">
+                            <span>{porcentaje}%</span>
+                            <div className="w-24 bg-blue-50 rounded-full h-1.5 overflow-hidden">
+                              <div
+                                className="bg-blue-600 h-full"
+                                style={{ width: `${percent}%` }}
+                              />
+                            </div>
+                          </div>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/dashboard/InformeTabs.tsx
+++ b/src/components/dashboard/InformeTabs.tsx
@@ -4,6 +4,8 @@ import {
   buildIntroduccion,
   type IntroduccionData,
 } from "@/report/introduccion";
+import TablaSociodemo from "@/components/TablaSociodemo";
+import { ReportPayload } from "@/types/report";
 import Generalidades from "./Generalidades";
 import Metodologia from "./Metodologia";
 
@@ -12,6 +14,7 @@ interface Props {
   introduccionData: IntroduccionData;
   narrativaSociodemo?: string;
   recomendacionesSociodemo?: string;
+  payload: ReportPayload;
 }
 
 export default function InformeTabs({
@@ -19,6 +22,7 @@ export default function InformeTabs({
   introduccionData,
   narrativaSociodemo,
   recomendacionesSociodemo,
+  payload,
 }: Props) {
   const [value, setValue] = useState("introduccion");
   const intro = buildIntroduccion(introduccionData);
@@ -56,12 +60,13 @@ export default function InformeTabs({
       </TabsContent>
       <TabsContent value="resultados">
         {narrativaSociodemo && (
-          <div className="text-[#313B4A] text-justify font-montserrat text-base leading-relaxed space-y-4">
+          <div className="text-[#313B4A] text-justify font-montserrat text-base leading-relaxed space-y-4 mb-6">
             <h3 className="text-lg font-semibold">Descripción sociodemográfica</h3>
             <p>{narrativaSociodemo}</p>
             {recomendacionesSociodemo && <p>{recomendacionesSociodemo}</p>}
           </div>
         )}
+        <TablaSociodemo payload={payload} />
       </TabsContent>
       <TabsContent value="estrategias" />
     </Tabs>


### PR DESCRIPTION
## Summary
- create TablaSociodemo component to render sociodemographic distributions with counts and percentages
- show table in informe results tab and wire report payload

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 40 problems)

------
https://chatgpt.com/codex/tasks/task_e_689aba4b44388331b258151ff672032e