### PR TITLE
Use shortNivelRiesgo for risk labels

### DIFF
--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -4,6 +4,7 @@ import * as XLSX from "xlsx";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { gatherFlatResults, FlatResult } from "@/utils/gatherResults";
 import { exportElementToPDF } from "@/utils/pdfExport";
+import { shortNivelRiesgo } from "@/utils/shortNivelRiesgo";
 import { usePdfExport } from "@/hooks/usePdfExport";
 import { dimensionesExtralaboral } from "@/data/esquemaExtralaboral";
 import { baremosFormaA } from "@/data/baremosFormaA";
@@ -420,7 +421,7 @@ export default function DashboardResultados({
       if (nivel) {
         total++;
         const base =
-          nivel === "Sin riesgo" ? "Muy bajo" : nivel.replace("Riesgo ", "");
+          nivel === "Sin riesgo" ? "Muy bajo" : shortNivelRiesgo(nivel);
         if (counts[base] !== undefined) counts[base] += 1;
         else invalid++;
       }


### PR DESCRIPTION
## Summary
- Use `shortNivelRiesgo` to normalize risk level labels in `DashboardResultados` and avoid invalid counts.
- Import `shortNivelRiesgo` from utilities.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 24 errors, 3 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689d1b6afe8483319fbfef55506e4ec8