### PR TITLE
Rename results tab to sociodemografia

### DIFF
--- a/src/components/dashboard/InformeTabs.tsx
+++ b/src/components/dashboard/InformeTabs.tsx
@@ -43,8 +43,8 @@ export default function InformeTabs({
         <TabsTrigger className={tabClass} value="metodologia">
           Metodología
         </TabsTrigger>
-        <TabsTrigger className={tabClass} value="resultados">
-          Resultados
+        <TabsTrigger className={tabClass} value="sociodemografia">
+          Sociodemografía
         </TabsTrigger>
         <TabsTrigger className={tabClass} value="estrategias">
           Estrategias
@@ -63,7 +63,7 @@ export default function InformeTabs({
         <TabsContent value="metodologia">
           <Metodologia />
         </TabsContent>
-        <TabsContent value="resultados">
+        <TabsContent value="sociodemografia">
           {narrativaSociodemo && (
             <div className="text-[#313B4A] text-justify font-montserrat text-base leading-relaxed space-y-4 mb-6">
               <h3 className="text-lg font-semibold">Descripción sociodemográfica</h3>


### PR DESCRIPTION
## Summary
- rename "Resultados" tab and content to "Sociodemografía" with updated value

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 24 errors, 3 warnings)

------
https://chatgpt.com/codex/tasks/task_e_689d2230df40833197ae3cd516caf8d7