### PR TITLE
feat: move leadership chart to graficas tab

### DIFF
--- a/src/components/dashboard/InformeTabs.tsx
+++ b/src/components/dashboard/InformeTabs.tsx
@@ -43,8 +43,11 @@ export default function InformeTabs({
         <TabsTrigger className={tabClass} value="metodologia">
           Metodología
         </TabsTrigger>
-        <TabsTrigger className={tabClass} value="resultados">
-          Resultados
+        <TabsTrigger className={tabClass} value="sociodemografia">
+          Sociodemografía
+        </TabsTrigger>
+        <TabsTrigger className={tabClass} value="graficas">
+          Gráficas
         </TabsTrigger>
         <TabsTrigger className={tabClass} value="estrategias">
           Estrategias
@@ -63,7 +66,7 @@ export default function InformeTabs({
         <TabsContent value="metodologia">
           <Metodologia />
         </TabsContent>
-        <TabsContent value="resultados">
+        <TabsContent value="sociodemografia">
           {narrativaSociodemo && (
             <div className="text-[#313B4A] text-justify font-montserrat text-base leading-relaxed space-y-4 mb-6">
               <h3 className="text-lg font-semibold">Descripción sociodemográfica</h3>
@@ -72,6 +75,8 @@ export default function InformeTabs({
             </div>
           )}
           <TablaSociodemo payload={payload} />
+        </TabsContent>
+        <TabsContent value="graficas">
           <RiskDistributionChart
             title="Caracteristicas del liderazgo Forma A y B"
             data={liderazgoData}


### PR DESCRIPTION
## Summary
- add `Sociodemografía` and new `Gráficas` tabs in InformeTabs
- show demographic narrative and table only in `Sociodemografía`
- move `RiskDistributionChart` to dedicated `Gráficas` tab

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 'nivelesRiesgo' is assigned a value but never used, Unexpected any in several files, 'NivelResumen' defined but never used, 'analytics' assigned a value but never used, Unexpected any in removeUndefined.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689d23a43b648331a81dc7b869d718c0