### PR TITLE
feat: add leadership domain risk distribution chart

### DIFF
--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -397,6 +397,43 @@ export default function DashboardResultados({
   const datosGlobalBE = datosMostrados.filter((d) => d.resultadoGlobalBExtralaboral);
 
   const levelsOrder = ["Muy bajo", "Bajo", "Medio", "Alto", "Muy alto"];
+  const liderazgoDominioData: RiskDistributionData = useMemo(() => {
+    const counts: Record<string, number> = {};
+    levelsOrder.forEach((lvl) => (counts[lvl] = 0));
+    let invalid = 0;
+    let total = 0;
+    const nombre = "Liderazgo y relaciones sociales en el trabajo";
+    [...datosA, ...datosB].forEach((d) => {
+      let seccion: any =
+        d.resultadoFormaA?.dominios?.[nombre] ||
+        d.resultadoFormaB?.dominios?.[nombre];
+      if (!seccion && Array.isArray(d.resultadoFormaA?.dominios)) {
+        seccion = (d.resultadoFormaA.dominios as any).find(
+          (x: any) => x.nombre === nombre
+        );
+      }
+      if (!seccion && Array.isArray(d.resultadoFormaB?.dominios)) {
+        seccion = (d.resultadoFormaB.dominios as any).find(
+          (x: any) => x.nombre === nombre
+        );
+      }
+      const nivel = seccion?.nivel;
+      if (nivel) {
+        total++;
+        const base =
+          nivel === "Sin riesgo" ? "Muy bajo" : shortNivelRiesgo(nivel);
+        if (counts[base] !== undefined) counts[base] += 1;
+        else invalid++;
+      }
+    });
+    const data: RiskDistributionData = {
+      total,
+      counts,
+      levelsOrder: [...levelsOrder],
+    };
+    if (invalid > 0) data.invalid = invalid;
+    return data;
+  }, [datosA, datosB]);
   const liderazgoData: RiskDistributionData = useMemo(() => {
     const counts: Record<string, number> = {};
     levelsOrder.forEach((lvl) => (counts[lvl] = 0));
@@ -1296,6 +1333,7 @@ export default function DashboardResultados({
                   narrativaSociodemo={narrativaSociodemo}
                   recomendacionesSociodemo={recomendacionesSociodemo}
                   payload={reportPayload}
+                  liderazgoDominioData={liderazgoDominioData}
                   liderazgoData={liderazgoData}
                 />
             </section>

--- a/src/components/dashboard/InformeTabs.tsx
+++ b/src/components/dashboard/InformeTabs.tsx
@@ -18,6 +18,7 @@ interface Props {
   narrativaSociodemo?: string;
   recomendacionesSociodemo?: string;
   payload: ReportPayload;
+  liderazgoDominioData: RiskDistributionData;
   liderazgoData: RiskDistributionData;
 }
 
@@ -27,6 +28,7 @@ export default function InformeTabs({
   narrativaSociodemo,
   recomendacionesSociodemo,
   payload,
+  liderazgoDominioData,
   liderazgoData,
 }: Props) {
   const [value, setValue] = useState("introduccion");
@@ -72,6 +74,10 @@ export default function InformeTabs({
             </div>
           )}
           <TablaSociodemo payload={payload} />
+          <RiskDistributionChart
+            title="DOMINIO LIDERAZGO Y RELACIONES SOCIALES EN EL TRABAJO FORMA A Y FORMA B"
+            data={liderazgoDominioData}
+          />
           <RiskDistributionChart
             title="Caracteristicas del liderazgo Forma A y B"
             data={liderazgoData}


### PR DESCRIPTION
## Summary
- compute risk distribution for the "Liderazgo y relaciones sociales en el trabajo" domain
- display new chart "DOMINIO LIDERAZGO Y RELACIONES SOCIALES EN EL TRABAJO FORMA A Y FORMA B" above existing leadership chart

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any / no-unused-vars across project)*

------
https://chatgpt.com/codex/tasks/task_e_689d25a3ad64833184236ec9c1fe50eb