### PR TITLE
Add leadership domain narrative with dynamic risk summary

### DIFF
--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -395,9 +395,17 @@ export default function DashboardResultados({
   const levelsOrder = ["Muy bajo", "Bajo", "Medio", "Alto", "Muy alto"];
   const liderazgoDominioData: RiskDistributionData = useMemo(() => {
     const counts: Record<string, number> = {};
-    levelsOrder.forEach((lvl) => (counts[lvl] = 0));
+    const countsA: Record<string, number> = {};
+    const countsB: Record<string, number> = {};
+    levelsOrder.forEach((lvl) => {
+      counts[lvl] = 0;
+      countsA[lvl] = 0;
+      countsB[lvl] = 0;
+    });
     let invalid = 0;
     let total = 0;
+    let totalA = 0;
+    let totalB = 0;
     const nombre = "Liderazgo y relaciones sociales en el trabajo";
     [...datosA, ...datosB].forEach((d) => {
       let seccion: any =
@@ -415,17 +423,31 @@ export default function DashboardResultados({
       }
       const nivel = seccion?.nivel;
       if (nivel) {
-        total++;
         const base =
           nivel === "Sin riesgo" ? "Muy bajo" : shortNivelRiesgo(nivel);
-        if (counts[base] !== undefined) counts[base] += 1;
-        else invalid++;
+        if (counts[base] !== undefined) {
+          counts[base] += 1;
+          if (d.tipo === "A") {
+            countsA[base] += 1;
+            totalA++;
+          } else {
+            countsB[base] += 1;
+            totalB++;
+          }
+          total++;
+        } else {
+          invalid++;
+        }
       }
     });
     const data: RiskDistributionData = {
       total,
       counts,
       levelsOrder: [...levelsOrder],
+      countsA,
+      countsB,
+      totalA,
+      totalB,
     };
     if (invalid > 0) data.invalid = invalid;
     return data;

--- a/src/components/RiskDistributionChart.tsx
+++ b/src/components/RiskDistributionChart.tsx
@@ -18,6 +18,10 @@ export type RiskDistributionData = {
   counts: Record<string, number>;
   levelsOrder: string[];
   invalid?: number;
+  countsA?: Record<string, number>;
+  countsB?: Record<string, number>;
+  totalA?: number;
+  totalB?: number;
 };
 
 interface Props {

--- a/src/components/dashboard/InformeTabs.tsx
+++ b/src/components/dashboard/InformeTabs.tsx
@@ -11,6 +11,7 @@ import RiskDistributionChart, {
 import { ReportPayload } from "@/types/report";
 import Generalidades from "./Generalidades";
 import Metodologia from "./Metodologia";
+import { buildRiskSentence } from "@/utils/riskSentence";
 
 interface Props {
   tabClass: string;
@@ -33,6 +34,13 @@ export default function InformeTabs({
 }: Props) {
   const [value, setValue] = useState("introduccion");
   const intro = buildIntroduccion(introduccionData);
+  const dominioSentence = buildRiskSentence({
+    levelsOrder: liderazgoDominioData.levelsOrder,
+    countsA: liderazgoDominioData.countsA || {},
+    countsB: liderazgoDominioData.countsB || {},
+    totalA: liderazgoDominioData.totalA || 0,
+    totalB: liderazgoDominioData.totalB || 0,
+  });
   return (
     <Tabs value={value} onValueChange={setValue} className="w-full">
       <TabsList className="mb-6 py-2 px-4 scroll-pl-4 w-full flex gap-2 overflow-x-auto whitespace-nowrap">
@@ -83,6 +91,12 @@ export default function InformeTabs({
             title="DOMINIO LIDERAZGO Y RELACIONES SOCIALES EN EL TRABAJO FORMA A Y FORMA B"
             data={liderazgoDominioData}
           />
+          <p className="mt-4 text-[#313B4A] text-justify font-montserrat text-base leading-relaxed">
+            Este dominio evalúa la calidad de la interacción con los superiores y compañeros, así como el apoyo social percibido en el entorno laboral. Un liderazgo deficiente y relaciones sociales conflictivas pueden ser fuentes importantes de riesgo psicosocial.
+          </p>
+          <p className="mt-4 text-[#313B4A] text-justify font-montserrat text-base leading-relaxed">
+            {dominioSentence}
+          </p>
           <RiskDistributionChart
             title="Caracteristicas del liderazgo Forma A y B"
             data={liderazgoData}

--- a/src/utils/riskSentence.ts
+++ b/src/utils/riskSentence.ts
@@ -1,0 +1,40 @@
+export interface RiskSentenceInput {
+  levelsOrder: string[];
+  countsA: Record<string, number>;
+  countsB: Record<string, number>;
+  totalA: number;
+  totalB: number;
+}
+
+export function buildRiskSentence({
+  levelsOrder,
+  countsA,
+  countsB,
+  totalA,
+  totalB,
+}: RiskSentenceInput): string {
+  const combined: Record<string, number> = {};
+  levelsOrder.forEach((lvl) => {
+    combined[lvl] = (countsA[lvl] || 0) + (countsB[lvl] || 0);
+  });
+  let modal = levelsOrder[0];
+  let max = combined[modal] || 0;
+  for (const lvl of levelsOrder) {
+    const value = combined[lvl] || 0;
+    if (value > max) {
+      max = value;
+      modal = lvl;
+    }
+  }
+  const fmt = (count: number, total: number) => {
+    if (!total || total <= 0) return "0,00%";
+    const pct = (count / total) * 100;
+    return pct.toLocaleString("es-CO", {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }) + "%";
+  };
+  const pctA = fmt(countsA[modal] || 0, totalA);
+  const pctB = fmt(countsB[modal] || 0, totalB);
+  return `Esta gráfica refiere mayor incidencia en el riesgo ${modal} para el ${pctA} de la población de la forma A y ${pctB} de la forma B.`;
+}


### PR DESCRIPTION
## Summary
- extend `RiskDistributionData` to hold per-form counts and totals
- add `buildRiskSentence` utility to generate modal risk narrative
- show leadership domain description and dynamic summary under first chart

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 33 problems)*

------
https://chatgpt.com/codex/tasks/task_e_689d2be51a5083319b5881376a51306e