### PR TITLE
Add animated risk gauge and suggestions to Graficas tab

### DIFF
--- a/src/components/SemaphoreDial.tsx
+++ b/src/components/SemaphoreDial.tsx
@@ -1,0 +1,56 @@
+import React, { useEffect, useState } from "react";
+
+type Stage = "primario" | "secundario" | "terciario";
+
+interface Props {
+  stage: Stage;
+}
+
+const stageAngles: Record<Stage, number> = {
+  primario: 60,
+  secundario: 180,
+  terciario: 300,
+};
+
+const stageLabels: Record<Stage, string> = {
+  primario: "Primario",
+  secundario: "Secundario",
+  terciario: "Terciario",
+};
+
+export default function SemaphoreDial({ stage }: Props) {
+  const [angle, setAngle] = useState(0);
+
+  useEffect(() => {
+    const id = setTimeout(() => {
+      setAngle(stageAngles[stage]);
+    }, 100);
+    return () => clearTimeout(id);
+  }, [stage]);
+
+  return (
+    <div className="relative w-24 h-24">
+      <div
+        className="absolute inset-0 rounded-full"
+        style={{
+          background:
+            "conic-gradient(#16a34a 0deg 120deg, #facc15 120deg 240deg, #dc2626 240deg 360deg)",
+        }}
+      />
+      <div className="absolute inset-[12%] bg-white rounded-full" />
+      <div
+        className="absolute left-1/2 top-1/2 w-0 h-0"
+        style={{ transform: "translate(-50%, -50%)" }}
+      >
+        <div
+          className="origin-bottom w-0.5 h-10 bg-black transition-transform duration-700"
+          style={{ transform: `translateX(-50%) rotate(${angle}deg)` }}
+        />
+      </div>
+      <div className="absolute inset-0 flex items-center justify-center text-xs font-semibold">
+        {stageLabels[stage]}
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/dashboard/InformeTabs.tsx
+++ b/src/components/dashboard/InformeTabs.tsx
@@ -12,6 +12,7 @@ import { ReportPayload } from "@/types/report";
 import Generalidades from "./Generalidades";
 import Metodologia from "./Metodologia";
 import { buildRiskSentence } from "@/utils/riskSentence";
+import SemaphoreDial from "@/components/SemaphoreDial";
 
 interface Props {
   tabClass: string;
@@ -41,6 +42,15 @@ export default function InformeTabs({
     totalA: liderazgoDominioData.totalA || 0,
     totalB: liderazgoDominioData.totalB || 0,
   });
+
+  const counts = liderazgoDominioData.counts;
+  const modalLevel = Object.keys(counts).reduce((max, key) =>
+    counts[key] > (counts[max] || 0) ? key : max,
+  "");
+  let stage: "primario" | "secundario" | "terciario" = "primario";
+  if (modalLevel === "Medio") stage = "secundario";
+  else if (modalLevel === "Alto" || modalLevel === "Muy alto")
+    stage = "terciario";
   return (
     <Tabs value={value} onValueChange={setValue} className="w-full">
       <TabsList className="mb-6 py-2 px-4 scroll-pl-4 w-full flex gap-2 overflow-x-auto whitespace-nowrap">
@@ -87,21 +97,53 @@ export default function InformeTabs({
           <TablaSociodemo payload={payload} />
         </TabsContent>
         <TabsContent value="graficas">
-          <RiskDistributionChart
-            title="DOMINIO LIDERAZGO Y RELACIONES SOCIALES EN EL TRABAJO FORMA A Y FORMA B"
-            data={liderazgoDominioData}
-          />
-          <p className="mt-4 text-[#313B4A] text-justify font-montserrat text-base leading-relaxed">
-            Este dominio evalúa la calidad de la interacción con los superiores y compañeros, así como el apoyo social percibido en el entorno laboral. Un liderazgo deficiente y relaciones sociales conflictivas pueden ser fuentes importantes de riesgo psicosocial.
-          </p>
-          <p className="mt-4 text-[#313B4A] text-justify font-montserrat text-base leading-relaxed">
-            {dominioSentence}
-          </p>
-          <RiskDistributionChart
-            title="Caracteristicas del liderazgo Forma A y B"
-            data={liderazgoData}
-          />
-        </TabsContent>
+        <RiskDistributionChart
+          title="DOMINIO LIDERAZGO Y RELACIONES SOCIALES EN EL TRABAJO FORMA A Y FORMA B"
+          data={liderazgoDominioData}
+        />
+        <p className="mt-4 text-[#313B4A] text-justify font-montserrat text-base leading-relaxed">
+          Este dominio evalúa la calidad de la interacción con los superiores y compañeros, así como el apoyo social percibido en el entorno laboral. Un liderazgo deficiente y relaciones sociales conflictivas pueden ser fuentes importantes de riesgo psicosocial.
+        </p>
+        <p className="mt-4 text-[#313B4A] text-justify font-montserrat text-base leading-relaxed">
+          {dominioSentence}
+        </p>
+        <div className="mt-4 flex flex-col md:flex-row items-start gap-4">
+          <SemaphoreDial stage={stage} />
+          <div className="text-[#313B4A] text-justify font-montserrat text-base leading-relaxed">
+            {stage === "primario" ? (
+              <p>
+                El dominio evaluado se encuentra en un nivel óptimo, sin presencia significativa de riesgo. No se requieren acciones adicionales ni planes de mejora inmediatos; sin embargo, es importante continuar fortaleciendo las prácticas actuales para mantener estos resultados. ¡Felicitaciones por destacar en esta área y seguir siendo un ejemplo de excelencia!
+              </p>
+            ) : (
+              <>
+                <p>
+                  El  Dominio Liderazgo y Relaciones Sociales en el Trabajo:  refiere la Calidad de las interacciones entre compañeros, cohesión del equipo y disponibilidad de apoyo social.<br />
+                  Ejemplo: Conflictos interpersonales, falta de apoyo entre compañeros, aislamiento social, acoso laboral.
+                </p>
+                <p className="font-semibold mt-2">Acciones de Intervención Sugeridas:</p>
+                <ol className="list-decimal ml-5 space-y-1">
+                  <li>
+                    Actividades de Integración y Construcción de Equipo (Team Building): Organizar eventos y actividades que fomenten la cohesión, el compañerismo y la integración entre los miembros del equipo.
+                  </li>
+                  <li>
+                    Mediación de Conflictos: Contar con un proceso formal de mediación para resolver conflictos interpersonales de manera constructiva.
+                  </li>
+                  <li>
+                    Fomentar la Colaboración y el Apoyo Mutuo: Crear un ambiente que valore la colaboración, el intercambio de conocimientos y el apoyo entre compañeros.
+                  </li>
+                  <li>
+                    Políticas de Cero Tolerancia al Acoso: Implementar y comunicar claramente políticas de prevención e intervención del acoso laboral.
+                  </li>
+                </ol>
+              </>
+            )}
+          </div>
+        </div>
+        <RiskDistributionChart
+          title="Caracteristicas del liderazgo Forma A y B"
+          data={liderazgoData}
+        />
+      </TabsContent>
         <TabsContent value="estrategias" />
       </Tabs>
     );


### PR DESCRIPTION
## Summary
- animate new semaphore gauge showing Primario, Secundario or Terciario levels
- display contextual suggestions beside the gauge in Graficas tab

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 29 errors, 4 warnings)*
- `npm run build` *(incomplete: build command stopped during transformation)*

------
https://chatgpt.com/codex/tasks/task_e_689d3671bdac8331a38bc988e65a5e9a