### PR TITLE
refactor: enhance semaphore dial appearance

### DIFF
--- a/src/components/SemaphoreDial.tsx
+++ b/src/components/SemaphoreDial.tsx
@@ -18,6 +18,12 @@ const stageLabels: Record<Stage, string> = {
   terciario: "Terciario",
 };
 
+const stageColors: Record<Stage, string> = {
+  primario: "#16a34a",
+  secundario: "#facc15",
+  terciario: "#dc2626",
+};
+
 export default function SemaphoreDial({ stage }: Props) {
   const [angle, setAngle] = useState(0);
 
@@ -28,8 +34,14 @@ export default function SemaphoreDial({ stage }: Props) {
     return () => clearTimeout(id);
   }, [stage]);
 
+  const labelAngle = stageAngles[stage];
+  const labelRadius = 65;
+  const angleRad = ((labelAngle - 90) * Math.PI) / 180;
+  const labelX = 50 + labelRadius * Math.cos(angleRad);
+  const labelY = 50 + labelRadius * Math.sin(angleRad);
+
   return (
-    <div className="relative w-24 h-24">
+    <div className="relative m-4 w-56 sm:w-64 aspect-square overflow-visible">
       <div
         className="absolute inset-0 rounded-full"
         style={{
@@ -37,17 +49,30 @@ export default function SemaphoreDial({ stage }: Props) {
             "conic-gradient(#16a34a 0deg 120deg, #facc15 120deg 240deg, #dc2626 240deg 360deg)",
         }}
       />
-      <div className="absolute inset-[12%] bg-white rounded-full" />
+      <div
+        className="absolute inset-[12%] rounded-full"
+        style={{ backgroundColor: stageColors[stage] }}
+      />
       <div
         className="absolute left-1/2 top-1/2 w-0 h-0"
         style={{ transform: "translate(-50%, -50%)" }}
       >
         <div
-          className="origin-bottom w-0.5 h-10 bg-black transition-transform duration-700"
-          style={{ transform: `translateX(-50%) rotate(${angle}deg)` }}
+          className="origin-bottom w-0.5 bg-black transition-transform duration-700"
+          style={{
+            height: "42%",
+            transform: `translateX(-50%) rotate(${angle}deg)`,
+          }}
         />
       </div>
-      <div className="absolute inset-0 flex items-center justify-center text-xs font-semibold">
+      <div
+        className="absolute text-sm font-semibold text-center"
+        style={{
+          left: `${labelX}%`,
+          top: `${labelY}%`,
+          transform: "translate(-50%, -50%)",
+        }}
+      >
         {stageLabels[stage]}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- make semaphore dial a true circle with responsive sizing and spacing
- position stage label outside dial aligned to corresponding color zone
- enlarge dial and color its center by current stage

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 33 problems (29 errors, 4 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_689d38fe3f8c8331976c7cc75ac284aa