### PR TITLE
refactor: enhance semaphore dial appearance

### DIFF
--- a/src/components/SemaphoreDial.tsx
+++ b/src/components/SemaphoreDial.tsx
@@ -18,6 +18,12 @@ const stageLabels: Record<Stage, string> = {
   terciario: "Terciario",
 };
 
+const stageColors: Record<Stage, string> = {
+  primario: "#16a34a",
+  secundario: "#facc15",
+  terciario: "#dc2626",
+};
+
 export default function SemaphoreDial({ stage }: Props) {
   const [angle, setAngle] = useState(0);
 
@@ -29,25 +35,36 @@ export default function SemaphoreDial({ stage }: Props) {
   }, [stage]);
 
   return (
-    <div className="relative w-24 h-24">
-      <div
-        className="absolute inset-0 rounded-full"
-        style={{
-          background:
-            "conic-gradient(#16a34a 0deg 120deg, #facc15 120deg 240deg, #dc2626 240deg 360deg)",
-        }}
-      />
-      <div className="absolute inset-[12%] bg-white rounded-full" />
-      <div
-        className="absolute left-1/2 top-1/2 w-0 h-0"
-        style={{ transform: "translate(-50%, -50%)" }}
-      >
+    <div className="m-4 w-56 sm:w-64 flex flex-col items-center">
+      <div className="relative w-full aspect-square overflow-visible">
         <div
-          className="origin-bottom w-0.5 h-10 bg-black transition-transform duration-700"
-          style={{ transform: `translateX(-50%) rotate(${angle}deg)` }}
+          className="absolute inset-0 rounded-full"
+          style={{
+            background:
+              "conic-gradient(#16a34a 0deg 120deg, #facc15 120deg 240deg, #dc2626 240deg 360deg)",
+          }}
         />
+        <div
+          className="absolute inset-[12%] rounded-full"
+          style={{ backgroundColor: stageColors[stage] }}
+        />
+        <div
+          className="absolute left-1/2 top-1/2 w-0 h-0"
+          style={{ transform: "translate(-50%, -50%)" }}
+        >
+          <div
+            className="origin-bottom w-0.5 bg-black transition-transform duration-700"
+            style={{
+              height: "42%",
+              transform: `translateX(-50%) rotate(${angle}deg)`,
+            }}
+          />
+        </div>
       </div>
-      <div className="absolute inset-0 flex items-center justify-center text-xs font-semibold">
+      <div
+        className="mt-2 text-sm font-semibold text-center"
+        style={{ color: stageColors[stage] }}
+      >
         {stageLabels[stage]}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- make semaphore dial a true circle with responsive sizing and spacing
- position stage label beneath dial and color it according to current stage
- enlarge dial and color its center by current stage

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 33 problems (29 errors, 4 warnings))*


------
https://chatgpt.com/codex/tasks/task_e_689d38fe3f8c8331976c7cc75ac284aa