### PR TITLE
refactor: enhance semaphore dial appearance

### DIFF
--- a/src/components/SemaphoreDial.tsx
+++ b/src/components/SemaphoreDial.tsx
@@ -18,6 +18,12 @@ const stageLabels: Record<Stage, string> = {
   terciario: "Terciario",
 };
 
+const stageColors: Record<Stage, string> = {
+  primario: "#16a34a",
+  secundario: "#facc15",
+  terciario: "#dc2626",
+};
+
 export default function SemaphoreDial({ stage }: Props) {
   const [angle, setAngle] = useState(0);
 
@@ -28,27 +34,47 @@ export default function SemaphoreDial({ stage }: Props) {
     return () => clearTimeout(id);
   }, [stage]);
 
+  const labelRadius = 60;
+  const rad = ((stageAngles[stage] - 90) * Math.PI) / 180;
+  const labelStyle = {
+    color: stageColors[stage],
+    left: `${50 + labelRadius * Math.cos(rad)}%`,
+    top: `${50 + labelRadius * Math.sin(rad)}%`,
+    transform: "translate(-50%, -50%)",
+  } as React.CSSProperties;
+
   return (
-    <div className="relative w-24 h-24">
-      <div
-        className="absolute inset-0 rounded-full"
-        style={{
-          background:
-            "conic-gradient(#16a34a 0deg 120deg, #facc15 120deg 240deg, #dc2626 240deg 360deg)",
-        }}
-      />
-      <div className="absolute inset-[12%] bg-white rounded-full" />
-      <div
-        className="absolute left-1/2 top-1/2 w-0 h-0"
-        style={{ transform: "translate(-50%, -50%)" }}
-      >
+    <div className="m-4 w-56 sm:w-64">
+      <div className="relative w-full aspect-square overflow-visible">
         <div
-          className="origin-bottom w-0.5 h-10 bg-black transition-transform duration-700"
-          style={{ transform: `translateX(-50%) rotate(${angle}deg)` }}
+          className="absolute inset-0 rounded-full"
+          style={{
+            background:
+              "conic-gradient(#16a34a 0deg 120deg, #facc15 120deg 240deg, #dc2626 240deg 360deg)",
+          }}
         />
-      </div>
-      <div className="absolute inset-0 flex items-center justify-center text-xs font-semibold">
-        {stageLabels[stage]}
+        <div
+          className="absolute inset-[12%] rounded-full"
+          style={{ backgroundColor: stageColors[stage] }}
+        />
+        <div
+          className="absolute left-1/2 top-1/2 w-0 h-0"
+          style={{ transform: "translate(-50%, -50%)" }}
+        >
+          <div
+            className="origin-bottom w-0.5 bg-black transition-transform duration-700"
+            style={{
+              height: "42%",
+              transform: `translateX(-50%) rotate(${angle}deg)`,
+            }}
+          />
+        </div>
+        <div
+          className="absolute text-sm font-semibold whitespace-nowrap"
+          style={labelStyle}
+        >
+          {stageLabels[stage]}
+        </div>
       </div>
     </div>
   );

--- a/src/components/dashboard/InformeTabs.tsx
+++ b/src/components/dashboard/InformeTabs.tsx
@@ -44,13 +44,19 @@ export default function InformeTabs({
   });
 
   const counts = liderazgoDominioData.counts;
-  const modalLevel = Object.keys(counts).reduce((max, key) =>
-    counts[key] > (counts[max] || 0) ? key : max,
-  "");
+  const stageCounts = { primario: 0, secundario: 0, terciario: 0 };
+  Object.entries(counts).forEach(([level, count]) => {
+    if (level === "Muy bajo" || level === "Bajo") stageCounts.primario += count;
+    else if (level === "Medio") stageCounts.secundario += count;
+    else if (level === "Alto" || level === "Muy alto") stageCounts.terciario += count;
+  });
   let stage: "primario" | "secundario" | "terciario" = "primario";
-  if (modalLevel === "Medio") stage = "secundario";
-  else if (modalLevel === "Alto" || modalLevel === "Muy alto")
+  if (
+    stageCounts.terciario >= stageCounts.secundario &&
+    stageCounts.terciario >= stageCounts.primario
+  )
     stage = "terciario";
+  else if (stageCounts.secundario >= stageCounts.primario) stage = "secundario";
   return (
     <Tabs value={value} onValueChange={setValue} className="w-full">
       <TabsList className="mb-6 py-2 px-4 scroll-pl-4 w-full flex gap-2 overflow-x-auto whitespace-nowrap">


### PR DESCRIPTION
## Summary
- align stage label with its color segment and keep it outside the dial
- choose the higher semaphore stage when category counts are tied

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 33 problems (29 errors, 4 warnings))*


------
https://chatgpt.com/codex/tasks/task_e_689d38fe3f8c8331976c7cc75ac284aa