### PR TITLE
feat: report independent risk modals

### DIFF
--- a/src/utils/riskSentence.ts
+++ b/src/utils/riskSentence.ts
@@ -13,28 +13,34 @@ export function buildRiskSentence({
   totalA,
   totalB,
 }: RiskSentenceInput): string {
-  const combined: Record<string, number> = {};
-  levelsOrder.forEach((lvl) => {
-    combined[lvl] = (countsA[lvl] || 0) + (countsB[lvl] || 0);
-  });
-  let modal = levelsOrder[0];
-  let max = combined[modal] || 0;
-  for (const lvl of levelsOrder) {
-    const value = combined[lvl] || 0;
-    if (value > max) {
-      max = value;
-      modal = lvl;
+  const findModal = (counts: Record<string, number>): string => {
+    let modal = levelsOrder[0];
+    let max = counts[modal] ?? 0;
+    for (const lvl of levelsOrder) {
+      const value = counts[lvl] ?? 0;
+      if (value > max) {
+        max = value;
+        modal = lvl;
+      }
     }
-  }
+    return modal;
+  };
+
   const fmt = (count: number, total: number) => {
     if (!total || total <= 0) return "0,00%";
     const pct = (count / total) * 100;
-    return pct.toLocaleString("es-CO", {
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-    }) + "%";
+    return (
+      pct.toLocaleString("es-CO", {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      }) + "%"
+    );
   };
-  const pctA = fmt(countsA[modal] || 0, totalA);
-  const pctB = fmt(countsB[modal] || 0, totalB);
-  return `Esta gráfica refiere mayor incidencia en el riesgo ${modal} para el ${pctA} de la población de la forma A y ${pctB} de la forma B.`;
+
+  const modalA = findModal(countsA);
+  const modalB = findModal(countsB);
+  const pctA = fmt(countsA[modalA] ?? 0, totalA);
+  const pctB = fmt(countsB[modalB] ?? 0, totalB);
+
+  return `Esta gráfica refiere mayor incidencia en el riesgo ${modalA} para el ${pctA} de la población de la forma A y mayor incidencia en el riesgo ${modalB} para el ${pctB} de la forma B.`;
 }


### PR DESCRIPTION
## Summary
- compute modal risk level separately for forms A and B
- format risk percentages per form with es-CO locale and handle zero totals

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 33 problems)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d4b0b5dcc833185768b05da602c74