### PR TITLE
Move semaphore label below dial

### DIFF
--- a/src/components/SemaphoreDial.tsx
+++ b/src/components/SemaphoreDial.tsx
@@ -33,17 +33,8 @@ export default function SemaphoreDial({ stage }: Props) {
     }, 100);
     return () => clearTimeout(id);
   }, [stage]);
-  const labelRadius = 60;
-  const rad = ((stageAngles[stage] - 90) * Math.PI) / 180;
-  const labelStyle = {
-    color: stageColors[stage],
-    left: `${50 + labelRadius * Math.cos(rad)}%`,
-    top: `${50 + labelRadius * Math.sin(rad)}%`,
-    transform: "translate(-50%, -50%)",
-  } as React.CSSProperties;
-
   return (
-    <div className="m-4 w-56 sm:w-64">
+    <div className="m-4 w-56 sm:w-64 flex flex-col items-center">
       <div className="relative w-full aspect-square overflow-visible">
         <div
           className="absolute inset-0 rounded-full"
@@ -68,12 +59,12 @@ export default function SemaphoreDial({ stage }: Props) {
             }}
           />
         </div>
-        <div
-          className="absolute text-sm font-semibold whitespace-nowrap"
-          style={labelStyle}
-        >
-          {stageLabels[stage]}
-        </div>
+      </div>
+      <div
+        className="mt-2 text-sm font-semibold whitespace-nowrap"
+        style={{ color: stageColors[stage] }}
+      >
+        {stageLabels[stage]}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- display semaphore stage label centered beneath the dial instead of around the edge

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 33 problems (29 errors, 4 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_689d4b8b05308331ad74e4231ea09765