### PR TITLE
feat: add Capacitacion dimension chart

### DIFF
--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -692,6 +692,66 @@ export default function DashboardResultados({
     return data;
   }, [datosA, datosB]);
 
+  const capacitacionData: RiskDistributionData = useMemo(() => {
+    const counts: Record<string, number> = {};
+    const countsA: Record<string, number> = {};
+    const countsB: Record<string, number> = {};
+    levelsOrder.forEach((lvl) => {
+      counts[lvl] = 0;
+      countsA[lvl] = 0;
+      countsB[lvl] = 0;
+    });
+    let invalid = 0;
+    let total = 0;
+    let totalA = 0;
+    let totalB = 0;
+    const nombre = "Capacitación";
+    [...datosA, ...datosB].forEach((d) => {
+      let seccion: any =
+        d.resultadoFormaA?.dimensiones?.[nombre] ||
+        d.resultadoFormaB?.dimensiones?.[nombre];
+      if (!seccion && Array.isArray(d.resultadoFormaA?.dimensiones)) {
+        seccion = d.resultadoFormaA.dimensiones.find(
+          (x: any) => x.nombre === nombre
+        );
+      }
+      if (!seccion && Array.isArray(d.resultadoFormaB?.dimensiones)) {
+        seccion = d.resultadoFormaB.dimensiones.find(
+          (x: any) => x.nombre === nombre
+        );
+      }
+      const nivel = seccion?.nivel;
+      if (nivel) {
+        const base =
+          nivel === "Sin riesgo" ? "Muy bajo" : shortNivelRiesgo(nivel);
+        if (counts[base] !== undefined) {
+          counts[base] += 1;
+          if (d.tipo === "A") {
+            countsA[base] += 1;
+            totalA++;
+          } else {
+            countsB[base] += 1;
+            totalB++;
+          }
+          total++;
+        } else {
+          invalid++;
+        }
+      }
+    });
+    const data: RiskDistributionData = {
+      total,
+      counts,
+      levelsOrder: [...levelsOrder],
+      countsA,
+      countsB,
+      totalA,
+      totalB,
+    };
+    if (invalid > 0) data.invalid = invalid;
+    return data;
+  }, [datosA, datosB]);
+
   const controlDominioData: RiskDistributionData = useMemo(() => {
     const counts: Record<string, number> = {};
     const countsA: Record<string, number> = {};
@@ -1559,6 +1619,7 @@ export default function DashboardResultados({
                   relacionesData={relacionesData}
                   retroalimentacionData={retroalimentacionData}
                   colaboradoresData={colaboradoresData}
+                  capacitacionData={capacitacionData}
                   controlDominioData={controlDominioData}
                 />
             </section>

--- a/src/components/dashboard/InformeTabs.tsx
+++ b/src/components/dashboard/InformeTabs.tsx
@@ -25,6 +25,7 @@ interface Props {
   relacionesData: RiskDistributionData;
   retroalimentacionData: RiskDistributionData;
   colaboradoresData: RiskDistributionData;
+  capacitacionData: RiskDistributionData;
   controlDominioData: RiskDistributionData;
 }
 
@@ -39,6 +40,7 @@ export default function InformeTabs({
   relacionesData,
   retroalimentacionData,
   colaboradoresData,
+  capacitacionData,
   controlDominioData,
 }: Props) {
   const [value, setValue] = useState("introduccion");
@@ -77,6 +79,13 @@ export default function InformeTabs({
     countsB: colaboradoresData.countsB || {},
     totalA: colaboradoresData.totalA || 0,
     totalB: colaboradoresData.totalB || 0,
+  });
+  const capacitacionSentence = buildRiskSentence({
+    levelsOrder: capacitacionData.levelsOrder,
+    countsA: capacitacionData.countsA || {},
+    countsB: capacitacionData.countsB || {},
+    totalA: capacitacionData.totalA || 0,
+    totalB: capacitacionData.totalB || 0,
   });
   const controlSentence = buildRiskSentence({
     levelsOrder: controlDominioData.levelsOrder,
@@ -131,6 +140,14 @@ export default function InformeTabs({
     : "primario";
   const showSuggestionsColaboradores =
     stageColaboradoresA !== "primario" || stageColaboradoresB !== "primario";
+  const stageCapacitacionA = capacitacionData.totalA
+    ? calcStage(capacitacionData.countsA || {})
+    : "primario";
+  const stageCapacitacionB = capacitacionData.totalB
+    ? calcStage(capacitacionData.countsB || {})
+    : "primario";
+  const showSuggestionsCapacitacion =
+    stageCapacitacionA !== "primario" || stageCapacitacionB !== "primario";
   const stageControlA = controlDominioData.totalA
     ? calcStage(controlDominioData.countsA || {})
     : "primario";
@@ -534,6 +551,70 @@ export default function InformeTabs({
             ) : (
               <p>
                 El dominio evaluado se encuentra en un nivel óptimo, sin presencia significativa de riesgo. No se requieren acciones adicionales ni planes de mejora inmediatos; sin embargo, es importante continuar fortaleciendo las prácticas actuales para mantener estos resultados. ¡Felicitaciones por destacar en esta área y seguir siendo un ejemplo de excelencia!
+              </p>
+            )}
+          </div>
+        </div>
+        <RiskDistributionChart
+          title="Capacitación Forma A y B"
+          data={capacitacionData}
+        />
+        <p className="mt-4 text-[#313B4A] text-justify font-montserrat text-base leading-relaxed">
+          Refiere las oportunidades de formación para adquirir nuevas habilidades o
+          mejorar las existentes, necesarias para el desempeño del trabajo.
+        </p>
+        <p className="mt-4 text-[#313B4A] text-justify font-montserrat text-base leading-relaxed">
+          {capacitacionSentence}
+        </p>
+        <div className="mt-4 flex flex-col md:flex-row items-start gap-4">
+          <div className="flex flex-col items-center gap-4">
+            <div className="flex flex-col items-center">
+              <p className="font-semibold">Forma A</p>
+              <SemaphoreDial stage={stageCapacitacionA} />
+            </div>
+            <div className="flex flex-col items-center">
+              <p className="font-semibold">Forma B</p>
+              <SemaphoreDial stage={stageCapacitacionB} />
+            </div>
+          </div>
+          <div className="text-[#313B4A] text-justify font-montserrat text-base leading-relaxed">
+            {showSuggestionsCapacitacion ? (
+              <>
+                <p>
+                  La Dimensión Capacitación: refiere las oportunidades de formación
+                  para adquirir nuevas habilidades o mejorar las existentes,
+                  necesarias para el desempeño del trabajo.<br />
+                  Ejemplo: Falta de formación para desempeñar nuevas tareas,
+                  tecnología o procesos, lo que genera inseguridad y estrés.
+                </p>
+                <p className="font-semibold mt-2">Acciones de Intervención Sugeridas:</p>
+                <ol className="list-decimal ml-5 space-y-1">
+                  <li>
+                    Diagnóstico de Necesidades de Capacitación: Realizar un
+                    diagnóstico sistemático de las necesidades de capacitación de
+                    los empleados.
+                  </li>
+                  <li>
+                    Plan de Capacitación Anual: Desarrollar un plan de capacitación
+                    anual que incluya temas relevantes para el desarrollo
+                    profesional y las necesidades del puesto.
+                  </li>
+                  <li>
+                    Diversificación de Métodos de Capacitación: Ofrecer diferentes
+                    modalidades de capacitación (presencial, virtual, talleres,
+                    e-learning) para adaptarse a las preferencias y
+                    disponibilidades de los empleados.
+                  </li>
+                </ol>
+              </>
+            ) : (
+              <p>
+                El dominio evaluado se encuentra en un nivel óptimo, sin presencia
+                significativa de riesgo. No se requieren acciones adicionales ni
+                planes de mejora inmediatos; sin embargo, es importante continuar
+                fortaleciendo las prácticas actuales para mantener estos
+                resultados. ¡Felicitaciones por destacar en esta área y seguir
+                siendo un ejemplo de excelencia!
               </p>
             )}
           </div>


### PR DESCRIPTION
## Summary
- compute and pass capacitacion dimension risk data
- display Capacitacion chart with description, semaphore and recommended interventions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 55 problems (46 errors, 9 warnings))*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689fef216130833186408be6e83400bd