### PR TITLE
feat: add Capacitacion dimension chart

### DIFF
--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -692,6 +692,126 @@ export default function DashboardResultados({
     return data;
   }, [datosA, datosB]);
 
+  const claridadData: RiskDistributionData = useMemo(() => {
+    const counts: Record<string, number> = {};
+    const countsA: Record<string, number> = {};
+    const countsB: Record<string, number> = {};
+    levelsOrder.forEach((lvl) => {
+      counts[lvl] = 0;
+      countsA[lvl] = 0;
+      countsB[lvl] = 0;
+    });
+    let invalid = 0;
+    let total = 0;
+    let totalA = 0;
+    let totalB = 0;
+    const nombre = "Claridad de rol";
+    [...datosA, ...datosB].forEach((d) => {
+      let seccion: any =
+        d.resultadoFormaA?.dimensiones?.[nombre] ||
+        d.resultadoFormaB?.dimensiones?.[nombre];
+      if (!seccion && Array.isArray(d.resultadoFormaA?.dimensiones)) {
+        seccion = d.resultadoFormaA.dimensiones.find(
+          (x: any) => x.nombre === nombre
+        );
+      }
+      if (!seccion && Array.isArray(d.resultadoFormaB?.dimensiones)) {
+        seccion = d.resultadoFormaB.dimensiones.find(
+          (x: any) => x.nombre === nombre
+        );
+      }
+      const nivel = seccion?.nivel;
+      if (nivel) {
+        const base =
+          nivel === "Sin riesgo" ? "Muy bajo" : shortNivelRiesgo(nivel);
+        if (counts[base] !== undefined) {
+          counts[base] += 1;
+          if (d.tipo === "A") {
+            countsA[base] += 1;
+            totalA++;
+          } else {
+            countsB[base] += 1;
+            totalB++;
+          }
+          total++;
+        } else {
+          invalid++;
+        }
+      }
+    });
+    const data: RiskDistributionData = {
+      total,
+      counts,
+      levelsOrder: [...levelsOrder],
+      countsA,
+      countsB,
+      totalA,
+      totalB,
+    };
+    if (invalid > 0) data.invalid = invalid;
+    return data;
+  }, [datosA, datosB]);
+
+  const capacitacionData: RiskDistributionData = useMemo(() => {
+    const counts: Record<string, number> = {};
+    const countsA: Record<string, number> = {};
+    const countsB: Record<string, number> = {};
+    levelsOrder.forEach((lvl) => {
+      counts[lvl] = 0;
+      countsA[lvl] = 0;
+      countsB[lvl] = 0;
+    });
+    let invalid = 0;
+    let total = 0;
+    let totalA = 0;
+    let totalB = 0;
+    const nombre = "Capacitación";
+    [...datosA, ...datosB].forEach((d) => {
+      let seccion: any =
+        d.resultadoFormaA?.dimensiones?.[nombre] ||
+        d.resultadoFormaB?.dimensiones?.[nombre];
+      if (!seccion && Array.isArray(d.resultadoFormaA?.dimensiones)) {
+        seccion = d.resultadoFormaA.dimensiones.find(
+          (x: any) => x.nombre === nombre
+        );
+      }
+      if (!seccion && Array.isArray(d.resultadoFormaB?.dimensiones)) {
+        seccion = d.resultadoFormaB.dimensiones.find(
+          (x: any) => x.nombre === nombre
+        );
+      }
+      const nivel = seccion?.nivel;
+      if (nivel) {
+        const base =
+          nivel === "Sin riesgo" ? "Muy bajo" : shortNivelRiesgo(nivel);
+        if (counts[base] !== undefined) {
+          counts[base] += 1;
+          if (d.tipo === "A") {
+            countsA[base] += 1;
+            totalA++;
+          } else {
+            countsB[base] += 1;
+            totalB++;
+          }
+          total++;
+        } else {
+          invalid++;
+        }
+      }
+    });
+    const data: RiskDistributionData = {
+      total,
+      counts,
+      levelsOrder: [...levelsOrder],
+      countsA,
+      countsB,
+      totalA,
+      totalB,
+    };
+    if (invalid > 0) data.invalid = invalid;
+    return data;
+  }, [datosA, datosB]);
+
   const controlDominioData: RiskDistributionData = useMemo(() => {
     const counts: Record<string, number> = {};
     const countsA: Record<string, number> = {};
@@ -1559,6 +1679,8 @@ export default function DashboardResultados({
                   relacionesData={relacionesData}
                   retroalimentacionData={retroalimentacionData}
                   colaboradoresData={colaboradoresData}
+                  claridadData={claridadData}
+                  capacitacionData={capacitacionData}
                   controlDominioData={controlDominioData}
                 />
             </section>

--- a/src/components/dashboard/InformeTabs.tsx
+++ b/src/components/dashboard/InformeTabs.tsx
@@ -25,6 +25,8 @@ interface Props {
   relacionesData: RiskDistributionData;
   retroalimentacionData: RiskDistributionData;
   colaboradoresData: RiskDistributionData;
+  claridadData: RiskDistributionData;
+  capacitacionData: RiskDistributionData;
   controlDominioData: RiskDistributionData;
 }
 
@@ -39,6 +41,8 @@ export default function InformeTabs({
   relacionesData,
   retroalimentacionData,
   colaboradoresData,
+  claridadData,
+  capacitacionData,
   controlDominioData,
 }: Props) {
   const [value, setValue] = useState("introduccion");
@@ -77,6 +81,20 @@ export default function InformeTabs({
     countsB: colaboradoresData.countsB || {},
     totalA: colaboradoresData.totalA || 0,
     totalB: colaboradoresData.totalB || 0,
+  });
+  const claridadSentence = buildRiskSentence({
+    levelsOrder: claridadData.levelsOrder,
+    countsA: claridadData.countsA || {},
+    countsB: claridadData.countsB || {},
+    totalA: claridadData.totalA || 0,
+    totalB: claridadData.totalB || 0,
+  });
+  const capacitacionSentence = buildRiskSentence({
+    levelsOrder: capacitacionData.levelsOrder,
+    countsA: capacitacionData.countsA || {},
+    countsB: capacitacionData.countsB || {},
+    totalA: capacitacionData.totalA || 0,
+    totalB: capacitacionData.totalB || 0,
   });
   const controlSentence = buildRiskSentence({
     levelsOrder: controlDominioData.levelsOrder,
@@ -131,6 +149,22 @@ export default function InformeTabs({
     : "primario";
   const showSuggestionsColaboradores =
     stageColaboradoresA !== "primario" || stageColaboradoresB !== "primario";
+  const stageClaridadA = claridadData.totalA
+    ? calcStage(claridadData.countsA || {})
+    : "primario";
+  const stageClaridadB = claridadData.totalB
+    ? calcStage(claridadData.countsB || {})
+    : "primario";
+  const showSuggestionsClaridad =
+    stageClaridadA !== "primario" || stageClaridadB !== "primario";
+  const stageCapacitacionA = capacitacionData.totalA
+    ? calcStage(capacitacionData.countsA || {})
+    : "primario";
+  const stageCapacitacionB = capacitacionData.totalB
+    ? calcStage(capacitacionData.countsB || {})
+    : "primario";
+  const showSuggestionsCapacitacion =
+    stageCapacitacionA !== "primario" || stageCapacitacionB !== "primario";
   const stageControlA = controlDominioData.totalA
     ? calcStage(controlDominioData.countsA || {})
     : "primario";
@@ -534,6 +568,130 @@ export default function InformeTabs({
             ) : (
               <p>
                 El dominio evaluado se encuentra en un nivel óptimo, sin presencia significativa de riesgo. No se requieren acciones adicionales ni planes de mejora inmediatos; sin embargo, es importante continuar fortaleciendo las prácticas actuales para mantener estos resultados. ¡Felicitaciones por destacar en esta área y seguir siendo un ejemplo de excelencia!
+              </p>
+            )}
+          </div>
+        </div>
+        <RiskDistributionChart
+          title="Claridad de rol Forma A y B"
+          data={claridadData}
+        />
+        <p className="mt-4 text-[#313B4A] text-justify font-montserrat text-base leading-relaxed">
+          Refiere al grado en que las funciones, responsabilidades y objetivos del
+          puesto están claramente definidos y comunicados.
+        </p>
+        <p className="mt-4 text-[#313B4A] text-justify font-montserrat text-base leading-relaxed">
+          {claridadSentence}
+        </p>
+        <div className="mt-4 flex flex-col md:flex-row items-start gap-4">
+          <div className="flex flex-col items-center gap-4">
+            <div className="flex flex-col items-center">
+              <p className="font-semibold">Forma A</p>
+              <SemaphoreDial stage={stageClaridadA} />
+            </div>
+            <div className="flex flex-col items-center">
+              <p className="font-semibold">Forma B</p>
+              <SemaphoreDial stage={stageClaridadB} />
+            </div>
+          </div>
+          <div className="text-[#313B4A] text-justify font-montserrat text-base leading-relaxed">
+            {showSuggestionsClaridad ? (
+              <>
+                <p>
+                  La Dimensión Claridad de rol: refiere al grado en que las
+                  responsabilidades y funciones están definidas y comunicadas.<br />
+                  Ejemplo: Falta de información sobre las tareas y expectativas,
+                  roles ambiguos o conflictivos.
+                </p>
+                <p className="font-semibold mt-2">Acciones de Intervención Sugeridas:</p>
+                <ol className="list-decimal ml-5 space-y-1">
+                  <li>
+                    Definición Clara de Roles y Responsabilidades: Establecer y
+                    documentar funciones, tareas y autoridad para cada puesto.
+                  </li>
+                  <li>
+                    Comunicación de Expectativas: Informar de manera permanente sobre
+                    objetivos, cambios en las funciones y criterios de desempeño.
+                  </li>
+                  <li>
+                    Retroalimentación y Acompañamiento: Brindar orientación y
+                    feedback para resolver dudas sobre el rol y mejorar el
+                    desempeño.
+                  </li>
+                </ol>
+              </>
+            ) : (
+              <p>
+                El dominio evaluado se encuentra en un nivel óptimo, sin presencia
+                significativa de riesgo. No se requieren acciones adicionales ni
+                planes de mejora inmediatos; sin embargo, es importante continuar
+                fortaleciendo las prácticas actuales para mantener estos resultados.
+                ¡Felicitaciones por destacar en esta área y seguir siendo un ejemplo
+                de excelencia!
+              </p>
+            )}
+          </div>
+        </div>
+        <RiskDistributionChart
+          title="Capacitación Forma A y B"
+          data={capacitacionData}
+        />
+        <p className="mt-4 text-[#313B4A] text-justify font-montserrat text-base leading-relaxed">
+          Refiere las oportunidades de formación para adquirir nuevas habilidades o
+          mejorar las existentes, necesarias para el desempeño del trabajo.
+        </p>
+        <p className="mt-4 text-[#313B4A] text-justify font-montserrat text-base leading-relaxed">
+          {capacitacionSentence}
+        </p>
+        <div className="mt-4 flex flex-col md:flex-row items-start gap-4">
+          <div className="flex flex-col items-center gap-4">
+            <div className="flex flex-col items-center">
+              <p className="font-semibold">Forma A</p>
+              <SemaphoreDial stage={stageCapacitacionA} />
+            </div>
+            <div className="flex flex-col items-center">
+              <p className="font-semibold">Forma B</p>
+              <SemaphoreDial stage={stageCapacitacionB} />
+            </div>
+          </div>
+          <div className="text-[#313B4A] text-justify font-montserrat text-base leading-relaxed">
+            {showSuggestionsCapacitacion ? (
+              <>
+                <p>
+                  La Dimensión Capacitación: refiere las oportunidades de formación
+                  para adquirir nuevas habilidades o mejorar las existentes,
+                  necesarias para el desempeño del trabajo.<br />
+                  Ejemplo: Falta de formación para desempeñar nuevas tareas,
+                  tecnología o procesos, lo que genera inseguridad y estrés.
+                </p>
+                <p className="font-semibold mt-2">Acciones de Intervención Sugeridas:</p>
+                <ol className="list-decimal ml-5 space-y-1">
+                  <li>
+                    Diagnóstico de Necesidades de Capacitación: Realizar un
+                    diagnóstico sistemático de las necesidades de capacitación de
+                    los empleados.
+                  </li>
+                  <li>
+                    Plan de Capacitación Anual: Desarrollar un plan de capacitación
+                    anual que incluya temas relevantes para el desarrollo
+                    profesional y las necesidades del puesto.
+                  </li>
+                  <li>
+                    Diversificación de Métodos de Capacitación: Ofrecer diferentes
+                    modalidades de capacitación (presencial, virtual, talleres,
+                    e-learning) para adaptarse a las preferencias y
+                    disponibilidades de los empleados.
+                  </li>
+                </ol>
+              </>
+            ) : (
+              <p>
+                El dominio evaluado se encuentra en un nivel óptimo, sin presencia
+                significativa de riesgo. No se requieren acciones adicionales ni
+                planes de mejora inmediatos; sin embargo, es importante continuar
+                fortaleciendo las prácticas actuales para mantener estos
+                resultados. ¡Felicitaciones por destacar en esta área y seguir
+                siendo un ejemplo de excelencia!
               </p>
             )}
           </div>


### PR DESCRIPTION
## Summary
- compute and pass Capacitacion and Claridad de rol risk data, positioning Capacitacion after Claridad de rol
- display Claridad de rol chart with description, semaphore and recommended interventions followed by Capacitacion section

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 59 problems (49 errors, 10 warnings))*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689fef216130833186408be6e83400bd