### PR TITLE
fix: remove duplicate claridad data declarations

### DIFF
--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -871,65 +871,6 @@ export default function DashboardResultados({
     if (invalid > 0) data.invalid = invalid;
     return data;
   }, [datosA, datosB]);
-  const claridadData: RiskDistributionData = useMemo(() => {
-    const counts: Record<string, number> = {};
-    const countsA: Record<string, number> = {};
-    const countsB: Record<string, number> = {};
-    levelsOrder.forEach((lvl) => {
-      counts[lvl] = 0;
-      countsA[lvl] = 0;
-      countsB[lvl] = 0;
-    });
-    let invalid = 0;
-    let total = 0;
-    let totalA = 0;
-    let totalB = 0;
-    const nombre = "Claridad de rol";
-    [...datosA, ...datosB].forEach((d) => {
-      let seccion: any =
-        d.resultadoFormaA?.dimensiones?.[nombre] ||
-        d.resultadoFormaB?.dimensiones?.[nombre];
-      if (!seccion && Array.isArray(d.resultadoFormaA?.dimensiones)) {
-        seccion = d.resultadoFormaA.dimensiones.find(
-          (x: any) => x.nombre === nombre
-        );
-      }
-      if (!seccion && Array.isArray(d.resultadoFormaB?.dimensiones)) {
-        seccion = d.resultadoFormaB.dimensiones.find(
-          (x: any) => x.nombre === nombre
-        );
-      }
-      const nivel = seccion?.nivel;
-      if (nivel) {
-        const base =
-          nivel === "Sin riesgo" ? "Muy bajo" : shortNivelRiesgo(nivel);
-        if (counts[base] !== undefined) {
-          counts[base] += 1;
-          if (d.tipo === "A") {
-            countsA[base] += 1;
-            totalA++;
-          } else {
-            countsB[base] += 1;
-            totalB++;
-          }
-          total++;
-        } else {
-          invalid++;
-        }
-      }
-    });
-    const data: RiskDistributionData = {
-      total,
-      counts,
-      levelsOrder: [...levelsOrder],
-      countsA,
-      countsB,
-      totalA,
-      totalB,
-    };
-    if (invalid > 0) data.invalid = invalid;
-    return data;
-  }, [datosA, datosB]);
   const ciudadInforme =
     datosMostrados.find((d) => d.ficha?.trabajoCiudad)?.ficha?.trabajoCiudad || "";
 
@@ -1738,7 +1679,6 @@ export default function DashboardResultados({
                   relacionesData={relacionesData}
                   retroalimentacionData={retroalimentacionData}
                   colaboradoresData={colaboradoresData}
-                  claridadData={claridadData}
                   capacitacionData={capacitacionData}
                   controlDominioData={controlDominioData}
                   claridadData={claridadData}

--- a/src/components/dashboard/InformeTabs.tsx
+++ b/src/components/dashboard/InformeTabs.tsx
@@ -28,7 +28,6 @@ interface Props {
   claridadData: RiskDistributionData;
   capacitacionData: RiskDistributionData;
   controlDominioData: RiskDistributionData;
-  claridadData: RiskDistributionData;
 }
 
 export default function InformeTabs({
@@ -45,7 +44,6 @@ export default function InformeTabs({
   claridadData,
   capacitacionData,
   controlDominioData,
-  claridadData,
 }: Props) {
   const [value, setValue] = useState("introduccion");
   const intro = buildIntroduccion(introduccionData);
@@ -175,14 +173,6 @@ export default function InformeTabs({
     : "primario";
   const showSuggestionsControl =
     stageControlA !== "primario" || stageControlB !== "primario";
-  const stageClaridadA = claridadData.totalA
-    ? calcStage(claridadData.countsA || {})
-    : "primario";
-  const stageClaridadB = claridadData.totalB
-    ? calcStage(claridadData.countsB || {})
-    : "primario";
-  const showSuggestionsClaridad =
-    stageClaridadA !== "primario" || stageClaridadB !== "primario";
   return (
     <Tabs value={value} onValueChange={setValue} className="w-full">
       <TabsList className="mb-6 py-2 px-4 scroll-pl-4 w-full flex gap-2 overflow-x-auto whitespace-nowrap">


### PR DESCRIPTION
## Summary
- remove duplicated `claridadData` prop declarations in InformeTabs
- drop redundant `claridadData` memo and prop usage in DashboardResultados
- clean up duplicated stage variables for Claridad in tabs component

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: 59 problems)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689ff3efd2688331a4c6cccaebe1601b