### PR TITLE
feat: add participation change management chart

### DIFF
--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -812,6 +812,66 @@ export default function DashboardResultados({
     return data;
   }, [datosA, datosB]);
 
+  const participacionData: RiskDistributionData = useMemo(() => {
+    const counts: Record<string, number> = {};
+    const countsA: Record<string, number> = {};
+    const countsB: Record<string, number> = {};
+    levelsOrder.forEach((lvl) => {
+      counts[lvl] = 0;
+      countsA[lvl] = 0;
+      countsB[lvl] = 0;
+    });
+    let invalid = 0;
+    let total = 0;
+    let totalA = 0;
+    let totalB = 0;
+    const nombre = "Participación y manejo del cambio";
+    [...datosA, ...datosB].forEach((d) => {
+      let seccion: any =
+        d.resultadoFormaA?.dimensiones?.[nombre] ||
+        d.resultadoFormaB?.dimensiones?.[nombre];
+      if (!seccion && Array.isArray(d.resultadoFormaA?.dimensiones)) {
+        seccion = d.resultadoFormaA.dimensiones.find(
+          (x: any) => x.nombre === nombre
+        );
+      }
+      if (!seccion && Array.isArray(d.resultadoFormaB?.dimensiones)) {
+        seccion = d.resultadoFormaB.dimensiones.find(
+          (x: any) => x.nombre === nombre
+        );
+      }
+      const nivel = seccion?.nivel;
+      if (nivel) {
+        const base =
+          nivel === "Sin riesgo" ? "Muy bajo" : shortNivelRiesgo(nivel);
+        if (counts[base] !== undefined) {
+          counts[base] += 1;
+          if (d.tipo === "A") {
+            countsA[base] += 1;
+            totalA++;
+          } else {
+            countsB[base] += 1;
+            totalB++;
+          }
+          total++;
+        } else {
+          invalid++;
+        }
+      }
+    });
+    const data: RiskDistributionData = {
+      total,
+      counts,
+      levelsOrder: [...levelsOrder],
+      countsA,
+      countsB,
+      totalA,
+      totalB,
+    };
+    if (invalid > 0) data.invalid = invalid;
+    return data;
+  }, [datosA, datosB]);
+
   const controlDominioData: RiskDistributionData = useMemo(() => {
     const counts: Record<string, number> = {};
     const countsA: Record<string, number> = {};
@@ -1679,9 +1739,10 @@ export default function DashboardResultados({
                   relacionesData={relacionesData}
                   retroalimentacionData={retroalimentacionData}
                   colaboradoresData={colaboradoresData}
-                  capacitacionData={capacitacionData}
-                  controlDominioData={controlDominioData}
                   claridadData={claridadData}
+                  capacitacionData={capacitacionData}
+                  participacionData={participacionData}
+                  controlDominioData={controlDominioData}
                 />
             </section>
           </div>

--- a/src/components/dashboard/InformeTabs.tsx
+++ b/src/components/dashboard/InformeTabs.tsx
@@ -27,6 +27,7 @@ interface Props {
   colaboradoresData: RiskDistributionData;
   claridadData: RiskDistributionData;
   capacitacionData: RiskDistributionData;
+  participacionData: RiskDistributionData;
   controlDominioData: RiskDistributionData;
 }
 
@@ -43,6 +44,7 @@ export default function InformeTabs({
   colaboradoresData,
   claridadData,
   capacitacionData,
+  participacionData,
   controlDominioData,
 }: Props) {
   const [value, setValue] = useState("introduccion");
@@ -95,6 +97,13 @@ export default function InformeTabs({
     countsB: capacitacionData.countsB || {},
     totalA: capacitacionData.totalA || 0,
     totalB: capacitacionData.totalB || 0,
+  });
+  const participacionSentence = buildRiskSentence({
+    levelsOrder: participacionData.levelsOrder,
+    countsA: participacionData.countsA || {},
+    countsB: participacionData.countsB || {},
+    totalA: participacionData.totalA || 0,
+    totalB: participacionData.totalB || 0,
   });
   const controlSentence = buildRiskSentence({
     levelsOrder: controlDominioData.levelsOrder,
@@ -165,6 +174,14 @@ export default function InformeTabs({
     : "primario";
   const showSuggestionsCapacitacion =
     stageCapacitacionA !== "primario" || stageCapacitacionB !== "primario";
+  const stageParticipacionA = participacionData.totalA
+    ? calcStage(participacionData.countsA || {})
+    : "primario";
+  const stageParticipacionB = participacionData.totalB
+    ? calcStage(participacionData.countsB || {})
+    : "primario";
+  const showSuggestionsParticipacion =
+    stageParticipacionA !== "primario" || stageParticipacionB !== "primario";
   const stageControlA = controlDominioData.totalA
     ? calcStage(controlDominioData.countsA || {})
     : "primario";
@@ -692,6 +709,72 @@ export default function InformeTabs({
                 fortaleciendo las prácticas actuales para mantener estos
                 resultados. ¡Felicitaciones por destacar en esta área y seguir
                 siendo un ejemplo de excelencia!
+              </p>
+            )}
+          </div>
+        </div>
+        <RiskDistributionChart
+          title="Participación y manejo del cambio Forma A y B"
+          data={participacionData}
+        />
+        <p className="mt-4 text-[#313B4A] text-justify font-montserrat text-base leading-relaxed">
+          Genera la posibilidad de influir en los cambios organizacionales y en la
+          forma en que se implementan.
+        </p>
+        <p className="mt-4 text-[#313B4A] text-justify font-montserrat text-base leading-relaxed">
+          {participacionSentence}
+        </p>
+        <div className="mt-4 flex flex-col md:flex-row items-start gap-4">
+          <div className="flex flex-col items-center gap-4">
+            <div className="flex flex-col items-center">
+              <p className="font-semibold">Forma A</p>
+              <SemaphoreDial stage={stageParticipacionA} />
+            </div>
+            <div className="flex flex-col items-center">
+              <p className="font-semibold">Forma B</p>
+              <SemaphoreDial stage={stageParticipacionB} />
+            </div>
+          </div>
+          <div className="text-[#313B4A] text-justify font-montserrat text-base leading-relaxed">
+            {showSuggestionsParticipacion ? (
+              <>
+                <p>
+                  La Dimensión Participación y manejo del cambio: Genera la
+                  posibilidad de influir en los cambios organizacionales y en la
+                  forma en que se implementan.
+                  <br />
+                  Ejemplo: Cambios organizacionales implementados sin consulta o
+                  explicación adecuada, generando incertidumbre y resistencia.
+                </p>
+                <p className="font-semibold mt-2">
+                  Acciones de Intervención Sugeridas:
+                </p>
+                <ol className="list-decimal ml-5 space-y-1">
+                  <li>
+                    Comunicación Transparente: Comunicar de forma clara y
+                    oportuna los motivos y el impacto de los cambios
+                    organizacionales.
+                  </li>
+                  <li>
+                    Canales de Participación: Establecer canales para que los
+                    empleados puedan expresar sus opiniones y sugerencias
+                    respecto a los cambios.
+                  </li>
+                  <li>
+                    Gestión del Cambio Participativa: Involucrar a los
+                    trabajadores en el diseño e implementación de los cambios,
+                    donde sea posible.
+                  </li>
+                </ol>
+              </>
+            ) : (
+              <p>
+                El dominio evaluado se encuentra en un nivel óptimo, sin
+                presencia significativa de riesgo. No se requieren acciones
+                adicionales ni planes de mejora inmediatos; sin embargo, es
+                importante continuar fortaleciendo las prácticas actuales para
+                mantener estos resultados. ¡Felicitaciones por destacar en esta
+                área y seguir siendo un ejemplo de excelencia!
               </p>
             )}
           </div>


### PR DESCRIPTION
## Summary
- add risk chart and guidance for "Participación y manejo del cambio"
- compute and pass participation data to report tabs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 52 errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ff6ed6ec48331bc1a717fe64d5384