### PR TITLE
feat: add jornada de trabajo chart

### DIFF
--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -1113,6 +1113,66 @@ export default function DashboardResultados({
     return data;
   }, [datosA, datosB]);
 
+  const demandasJornadaData: RiskDistributionData = useMemo(() => {
+    const counts: Record<string, number> = {};
+    const countsA: Record<string, number> = {};
+    const countsB: Record<string, number> = {};
+    levelsOrder.forEach((lvl) => {
+      counts[lvl] = 0;
+      countsA[lvl] = 0;
+      countsB[lvl] = 0;
+    });
+    let invalid = 0;
+    let total = 0;
+    let totalA = 0;
+    let totalB = 0;
+    const nombre = "Demandas de la jornada de trabajo";
+    [...datosA, ...datosB].forEach((d) => {
+      let seccion: any =
+        d.resultadoFormaA?.dimensiones?.[nombre] ||
+        d.resultadoFormaB?.dimensiones?.[nombre];
+      if (!seccion && Array.isArray(d.resultadoFormaA?.dimensiones)) {
+        seccion = d.resultadoFormaA.dimensiones.find(
+          (x: any) => x.nombre === nombre
+        );
+      }
+      if (!seccion && Array.isArray(d.resultadoFormaB?.dimensiones)) {
+        seccion = d.resultadoFormaB.dimensiones.find(
+          (x: any) => x.nombre === nombre
+        );
+      }
+      const nivel = seccion?.nivel;
+      if (nivel) {
+        const base =
+          nivel === "Sin riesgo" ? "Muy bajo" : shortNivelRiesgo(nivel);
+        if (counts[base] !== undefined) {
+          counts[base] += 1;
+          if (d.tipo === "A") {
+            countsA[base] += 1;
+            totalA++;
+          } else {
+            countsB[base] += 1;
+            totalB++;
+          }
+          total++;
+        } else {
+          invalid++;
+        }
+      }
+    });
+    const data: RiskDistributionData = {
+      total,
+      counts,
+      levelsOrder: [...levelsOrder],
+      countsA,
+      countsB,
+      totalA,
+      totalB,
+    };
+    if (invalid > 0) data.invalid = invalid;
+    return data;
+  }, [datosA, datosB]);
+
   const demandasDominioData: RiskDistributionData = useMemo(() => {
     const counts: Record<string, number> = {};
     const countsA: Record<string, number> = {};
@@ -1988,6 +2048,7 @@ export default function DashboardResultados({
                   controlDominioData={controlDominioData}
                   demandasDominioData={demandasDominioData}
                   demandasAmbientalesData={demandasAmbientalesData}
+                  demandasJornadaData={demandasJornadaData}
                 />
             </section>
           </div>

--- a/src/components/dashboard/InformeTabs.tsx
+++ b/src/components/dashboard/InformeTabs.tsx
@@ -33,6 +33,7 @@ interface Props {
   controlDominioData: RiskDistributionData;
   demandasDominioData: RiskDistributionData;
   demandasAmbientalesData: RiskDistributionData;
+  demandasJornadaData: RiskDistributionData;
 }
 
 export default function InformeTabs({
@@ -54,6 +55,7 @@ export default function InformeTabs({
   controlDominioData,
   demandasDominioData,
   demandasAmbientalesData,
+  demandasJornadaData,
 }: Props) {
   const [value, setValue] = useState("introduccion");
   const intro = buildIntroduccion(introduccionData);
@@ -147,6 +149,13 @@ export default function InformeTabs({
     countsB: demandasAmbientalesData.countsB || {},
     totalA: demandasAmbientalesData.totalA || 0,
     totalB: demandasAmbientalesData.totalB || 0,
+  });
+  const demandasJornadaSentence = buildRiskSentence({
+    levelsOrder: demandasJornadaData.levelsOrder,
+    countsA: demandasJornadaData.countsA || {},
+    countsB: demandasJornadaData.countsB || {},
+    totalA: demandasJornadaData.totalA || 0,
+    totalB: demandasJornadaData.totalB || 0,
   });
 
   type Stage = "primario" | "secundario" | "terciario";
@@ -259,6 +268,15 @@ export default function InformeTabs({
   const showSuggestionsDemandasAmbientales =
     stageDemandasAmbientalesA !== "primario" ||
     stageDemandasAmbientalesB !== "primario";
+  const stageDemandasJornadaA = demandasJornadaData.totalA
+    ? calcStage(demandasJornadaData.countsA || {})
+    : "primario";
+  const stageDemandasJornadaB = demandasJornadaData.totalB
+    ? calcStage(demandasJornadaData.countsB || {})
+    : "primario";
+  const showSuggestionsDemandasJornada =
+    stageDemandasJornadaA !== "primario" ||
+    stageDemandasJornadaB !== "primario";
   return (
     <Tabs value={value} onValueChange={setValue} className="w-full">
       <TabsList className="mb-6 py-2 px-4 scroll-pl-4 w-full flex gap-2 overflow-x-auto whitespace-nowrap">
@@ -1065,6 +1083,59 @@ export default function InformeTabs({
                   </li>
                   <li>
                     Programas de Seguridad y Salud en el Trabajo: Reforzar los programas de seguridad industrial y salud ocupacional para prevenir accidentes y enfermedades laborales.
+                  </li>
+                </ol>
+              </>
+            ) : (
+              <p>
+                El dominio evaluado se encuentra en un nivel óptimo, sin presencia significativa de riesgo. No se requieren acciones adicionales ni planes de mejora inmediatos; sin embargo, es importante continuar fortaleciendo las prácticas actuales para mantener estos resultados. ¡Felicitaciones por destacar en esta área y seguir siendo un ejemplo de excelencia!
+              </p>
+            )}
+          </div>
+        </div>
+        <RiskDistributionChart
+          title="Demandas de la jornada de trabajo Forma A y B"
+          data={demandasJornadaData}
+        />
+        <p className="mt-4 text-[#313B4A] text-justify font-montserrat text-base leading-relaxed">
+          Refiere la extensión, flexibilidad y distribución de la jornada laboral, incluyendo turnos y horas extras.
+        </p>
+        <p className="mt-4 text-[#313B4A] text-justify font-montserrat text-base leading-relaxed">
+          {demandasJornadaSentence}
+        </p>
+        <div className="mt-4 flex flex-col md:flex-row items-start gap-4">
+          <div className="flex flex-col items-center gap-4">
+            <div className="flex flex-col items-center">
+              <p className="font-semibold">Forma A</p>
+              <SemaphoreDial stage={stageDemandasJornadaA} />
+            </div>
+            <div className="flex flex-col items-center">
+              <p className="font-semibold">Forma B</p>
+              <SemaphoreDial stage={stageDemandasJornadaB} />
+            </div>
+          </div>
+          <div className="text-[#313B4A] text-justify font-montserrat text-base leading-relaxed">
+            {showSuggestionsDemandasJornada ? (
+              <>
+                <p>
+                  Ejemplo: Jornadas laborales excesivamente largas, trabajo por turnos que afecta el ciclo circadiano, falta de flexibilidad en los horarios, trabajo nocturno.
+                </p>
+                <p className="font-semibold mt-2">Acciones de Intervención Sugeridas:</p>
+                <ol className="list-decimal ml-5 space-y-1">
+                  <li>
+                    Políticas de Horarios Flexibles: Explorar la implementación de horarios flexibles o modalidades de teletrabajo cuando sea posible y adecuado.
+                  </li>
+                  <li>
+                    Gestión de Horas Extras: Monitorear y limitar las horas extras, asegurando que sean voluntarias y compensadas adecuadamente.
+                  </li>
+                  <li>
+                    Diseño de Turnos Equitativos: Optimizar los sistemas de turnos para minimizar el impacto en la salud y vida personal de los trabajadores.
+                  </li>
+                  <li>
+                    Fomento del Equilibrio Vida-Trabajo: Promover una cultura organizacional que valore el equilibrio entre la vida laboral y personal, desincentivando la "cultura del presentismo".
+                  </li>
+                  <li>
+                    Verifique los problemas de salud mental que puedan exacerbar síntomas y empeorar la salud de los colaboradores.
                   </li>
                 </ol>
               </>


### PR DESCRIPTION
## Summary
- add risk distribution chart for Dimensión Demandas de la jornada de trabajo
- include narrative text, semaphore dials and intervention suggestions
- wire up jornada data in dashboard results

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 85 problems)


------
https://chatgpt.com/codex/tasks/task_e_68a385140018833193d566f3544faf24