### PR TITLE
Add mental workload demand chart to report graphs

### DIFF
--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -1113,6 +1113,66 @@ export default function DashboardResultados({
     return data;
   }, [datosA, datosB]);
 
+  const demandasCargaMentalData: RiskDistributionData = useMemo(() => {
+    const counts: Record<string, number> = {};
+    const countsA: Record<string, number> = {};
+    const countsB: Record<string, number> = {};
+    levelsOrder.forEach((lvl) => {
+      counts[lvl] = 0;
+      countsA[lvl] = 0;
+      countsB[lvl] = 0;
+    });
+    let invalid = 0;
+    let total = 0;
+    let totalA = 0;
+    let totalB = 0;
+    const nombre = "Demandas de carga mental";
+    [...datosA, ...datosB].forEach((d) => {
+      let seccion: any =
+        d.resultadoFormaA?.dimensiones?.[nombre] ||
+        d.resultadoFormaB?.dimensiones?.[nombre];
+      if (!seccion && Array.isArray(d.resultadoFormaA?.dimensiones)) {
+        seccion = d.resultadoFormaA.dimensiones.find(
+          (x: any) => x.nombre === nombre
+        );
+      }
+      if (!seccion && Array.isArray(d.resultadoFormaB?.dimensiones)) {
+        seccion = d.resultadoFormaB.dimensiones.find(
+          (x: any) => x.nombre === nombre
+        );
+      }
+      const nivel = seccion?.nivel;
+      if (nivel) {
+        const base =
+          nivel === "Sin riesgo" ? "Muy bajo" : shortNivelRiesgo(nivel);
+        if (counts[base] !== undefined) {
+          counts[base] += 1;
+          if (d.tipo === "A") {
+            countsA[base] += 1;
+            totalA++;
+          } else {
+            countsB[base] += 1;
+            totalB++;
+          }
+          total++;
+        } else {
+          invalid++;
+        }
+      }
+    });
+    const data: RiskDistributionData = {
+      total,
+      counts,
+      levelsOrder: [...levelsOrder],
+      countsA,
+      countsB,
+      totalA,
+      totalB,
+    };
+    if (invalid > 0) data.invalid = invalid;
+    return data;
+  }, [datosA, datosB]);
+
   const demandasJornadaData: RiskDistributionData = useMemo(() => {
     const counts: Record<string, number> = {};
     const countsA: Record<string, number> = {};
@@ -2108,6 +2168,7 @@ export default function DashboardResultados({
                   controlDominioData={controlDominioData}
                   demandasDominioData={demandasDominioData}
                   demandasAmbientalesData={demandasAmbientalesData}
+                  demandasCargaMentalData={demandasCargaMentalData}
                   demandasJornadaData={demandasJornadaData}
                   consistenciaRolData={consistenciaRolData}
                 />

--- a/src/components/dashboard/InformeTabs.tsx
+++ b/src/components/dashboard/InformeTabs.tsx
@@ -33,6 +33,7 @@ interface Props {
   controlDominioData: RiskDistributionData;
   demandasDominioData: RiskDistributionData;
   demandasAmbientalesData: RiskDistributionData;
+  demandasCargaMentalData: RiskDistributionData;
   demandasJornadaData: RiskDistributionData;
   consistenciaRolData: RiskDistributionData;
 }
@@ -56,6 +57,7 @@ export default function InformeTabs({
   controlDominioData,
   demandasDominioData,
   demandasAmbientalesData,
+  demandasCargaMentalData,
   demandasJornadaData,
   consistenciaRolData,
 }: Props) {
@@ -151,6 +153,13 @@ export default function InformeTabs({
     countsB: demandasAmbientalesData.countsB || {},
     totalA: demandasAmbientalesData.totalA || 0,
     totalB: demandasAmbientalesData.totalB || 0,
+  });
+  const demandasCargaMentalSentence = buildRiskSentence({
+    levelsOrder: demandasCargaMentalData.levelsOrder,
+    countsA: demandasCargaMentalData.countsA || {},
+    countsB: demandasCargaMentalData.countsB || {},
+    totalA: demandasCargaMentalData.totalA || 0,
+    totalB: demandasCargaMentalData.totalB || 0,
   });
   const demandasJornadaSentence = buildRiskSentence({
     levelsOrder: demandasJornadaData.levelsOrder,
@@ -277,6 +286,15 @@ export default function InformeTabs({
   const showSuggestionsDemandasAmbientales =
     stageDemandasAmbientalesA !== "primario" ||
     stageDemandasAmbientalesB !== "primario";
+  const stageDemandasCargaMentalA = demandasCargaMentalData.totalA
+    ? calcStage(demandasCargaMentalData.countsA || {})
+    : "primario";
+  const stageDemandasCargaMentalB = demandasCargaMentalData.totalB
+    ? calcStage(demandasCargaMentalData.countsB || {})
+    : "primario";
+  const showSuggestionsDemandasCargaMental =
+    stageDemandasCargaMentalA !== "primario" ||
+    stageDemandasCargaMentalB !== "primario";
   const stageDemandasJornadaA = demandasJornadaData.totalA
     ? calcStage(demandasJornadaData.countsA || {})
     : "primario";
@@ -1219,6 +1237,56 @@ export default function InformeTabs({
                 importante continuar fortaleciendo las prácticas actuales para
                 mantener estos resultados. ¡Felicitaciones por destacar en esta
                 área y seguir siendo un ejemplo de excelencia!
+              </p>
+            )}
+          </div>
+        </div>
+        <RiskDistributionChart
+          title="Demandas de carga mental Forma A y B"
+          data={demandasCargaMentalData}
+        />
+        <p className="mt-4 text-[#313B4A] text-justify font-montserrat text-base leading-relaxed">
+          Son las Exigencias de procesamiento cognitivo que implica la tarea, como la minuciosidad, concentración, complejidad y variedad.
+        </p>
+        <p className="mt-4 text-[#313B4A] text-justify font-montserrat text-base leading-relaxed">
+          {demandasCargaMentalSentence}
+        </p>
+        <div className="mt-4 flex flex-col md:flex-row items-start gap-4">
+          <div className="flex flex-col items-center gap-4">
+            <div className="flex flex-col items-center">
+              <p className="font-semibold">Forma A</p>
+              <SemaphoreDial stage={stageDemandasCargaMentalA} />
+            </div>
+            <div className="flex flex-col items-center">
+              <p className="font-semibold">Forma B</p>
+              <SemaphoreDial stage={stageDemandasCargaMentalB} />
+            </div>
+          </div>
+          <div className="text-[#313B4A] text-justify font-montserrat text-base leading-relaxed">
+            {showSuggestionsDemandasCargaMental ? (
+              <>
+                <p>
+                  Ejemplo: Tareas que requieren alta concentración, resolución de problemas complejos, toma de decisiones rápidas, multitarea constante o trabajo monótono que genera fatiga mental.
+                </p>
+                <p className="font-semibold mt-2">Acciones de Intervención Sugeridas:</p>
+                <ol className="list-decimal ml-5 space-y-1">
+                  <li>
+                    Rotación de Tareas: Implementar la rotación de tareas para reducir la monotonía y la fatiga mental en trabajos repetitivos.
+                  </li>
+                  <li>
+                    Pausas Activas y Cognitivas: Fomentar y estructurar pausas regulares que permitan a los trabajadores desconectarse brevemente de sus tareas y recargar energías.
+                  </li>
+                  <li>
+                    Diseño de Puestos de Trabajo: Rediseñar tareas o procesos para simplificar su complejidad o proporcionar herramientas que faciliten el trabajo cognitivo.
+                  </li>
+                  <li>
+                    Capacitación en Manejo del Estrés: Ofrecer talleres sobre técnicas de relajación, mindfulness y afrontamiento del estrés para mejorar la resiliencia mental.
+                  </li>
+                </ol>
+              </>
+            ) : (
+              <p>
+                El dominio evaluado se encuentra en un nivel óptimo, sin presencia significativa de riesgo. No se requieren acciones adicionales ni planes de mejora inmediatos; sin embargo, es importante continuar fortaleciendo las prácticas actuales para mantener estos resultados. ¡Felicitaciones por destacar en esta área y seguir siendo un ejemplo de excelencia!
               </p>
             )}
           </div>


### PR DESCRIPTION
## Summary
- compute and expose mental workload demand distribution data
- display "Demandas de carga mental" chart with description, risk sentence, semaphores, and suggestions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 93 problems, see logs)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a38ba84fc0833192a60c88bfcde94b