### PR TITLE
Add Demandas cuantitativas chart to informe graphs

### DIFF
--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -1113,6 +1113,66 @@ export default function DashboardResultados({
     return data;
   }, [datosA, datosB]);
 
+  const demandasCuantitativasData: RiskDistributionData = useMemo(() => {
+    const counts: Record<string, number> = {};
+    const countsA: Record<string, number> = {};
+    const countsB: Record<string, number> = {};
+    levelsOrder.forEach((lvl) => {
+      counts[lvl] = 0;
+      countsA[lvl] = 0;
+      countsB[lvl] = 0;
+    });
+    let invalid = 0;
+    let total = 0;
+    let totalA = 0;
+    let totalB = 0;
+    const nombre = "Demandas cuantitativas";
+    [...datosA, ...datosB].forEach((d) => {
+      let seccion: any =
+        d.resultadoFormaA?.dimensiones?.[nombre] ||
+        d.resultadoFormaB?.dimensiones?.[nombre];
+      if (!seccion && Array.isArray(d.resultadoFormaA?.dimensiones)) {
+        seccion = d.resultadoFormaA.dimensiones.find(
+          (x: any) => x.nombre === nombre
+        );
+      }
+      if (!seccion && Array.isArray(d.resultadoFormaB?.dimensiones)) {
+        seccion = d.resultadoFormaB.dimensiones.find(
+          (x: any) => x.nombre === nombre
+        );
+      }
+      const nivel = seccion?.nivel;
+      if (nivel) {
+        const base =
+          nivel === "Sin riesgo" ? "Muy bajo" : shortNivelRiesgo(nivel);
+        if (counts[base] !== undefined) {
+          counts[base] += 1;
+          if (d.tipo === "A") {
+            countsA[base] += 1;
+            totalA++;
+          } else {
+            countsB[base] += 1;
+            totalB++;
+          }
+          total++;
+        } else {
+          invalid++;
+        }
+      }
+    });
+    const data: RiskDistributionData = {
+      total,
+      counts,
+      levelsOrder: [...levelsOrder],
+      countsA,
+      countsB,
+      totalA,
+      totalB,
+    };
+    if (invalid > 0) data.invalid = invalid;
+    return data;
+  }, [datosA, datosB]);
+
   const exigenciasResponsabilidadData: RiskDistributionData = useMemo(() => {
     const counts: Record<string, number> = {};
     const countsA: Record<string, number> = {};
@@ -2228,6 +2288,7 @@ export default function DashboardResultados({
                   controlDominioData={controlDominioData}
                   demandasDominioData={demandasDominioData}
                   demandasAmbientalesData={demandasAmbientalesData}
+                  demandasCuantitativasData={demandasCuantitativasData}
                   exigenciasResponsabilidadData={exigenciasResponsabilidadData}
                   demandasCargaMentalData={demandasCargaMentalData}
                   demandasJornadaData={demandasJornadaData}

--- a/src/components/dashboard/InformeTabs.tsx
+++ b/src/components/dashboard/InformeTabs.tsx
@@ -33,6 +33,7 @@ interface Props {
   controlDominioData: RiskDistributionData;
   demandasDominioData: RiskDistributionData;
   demandasAmbientalesData: RiskDistributionData;
+  demandasCuantitativasData: RiskDistributionData;
   exigenciasResponsabilidadData: RiskDistributionData;
   demandasCargaMentalData: RiskDistributionData;
   demandasJornadaData: RiskDistributionData;
@@ -58,6 +59,7 @@ export default function InformeTabs({
   controlDominioData,
   demandasDominioData,
   demandasAmbientalesData,
+  demandasCuantitativasData,
   exigenciasResponsabilidadData,
   demandasCargaMentalData,
   demandasJornadaData,
@@ -155,6 +157,13 @@ export default function InformeTabs({
     countsB: demandasAmbientalesData.countsB || {},
     totalA: demandasAmbientalesData.totalA || 0,
     totalB: demandasAmbientalesData.totalB || 0,
+  });
+  const demandasCuantitativasSentence = buildRiskSentence({
+    levelsOrder: demandasCuantitativasData.levelsOrder,
+    countsA: demandasCuantitativasData.countsA || {},
+    countsB: demandasCuantitativasData.countsB || {},
+    totalA: demandasCuantitativasData.totalA || 0,
+    totalB: demandasCuantitativasData.totalB || 0,
   });
   const exigenciasResponsabilidadSentence = buildRiskSentence({
     levelsOrder: exigenciasResponsabilidadData.levelsOrder,
@@ -295,6 +304,15 @@ export default function InformeTabs({
   const showSuggestionsDemandasAmbientales =
     stageDemandasAmbientalesA !== "primario" ||
     stageDemandasAmbientalesB !== "primario";
+  const stageDemandasCuantitativasA = demandasCuantitativasData.totalA
+    ? calcStage(demandasCuantitativasData.countsA || {})
+    : "primario";
+  const stageDemandasCuantitativasB = demandasCuantitativasData.totalB
+    ? calcStage(demandasCuantitativasData.countsB || {})
+    : "primario";
+  const showSuggestionsDemandasCuantitativas =
+    stageDemandasCuantitativasA !== "primario" ||
+    stageDemandasCuantitativasB !== "primario";
   const stageDemandasCargaMentalA = demandasCargaMentalData.totalA
     ? calcStage(demandasCargaMentalData.countsA || {})
     : "primario";
@@ -1333,37 +1351,87 @@ export default function InformeTabs({
             </div>
           </div>
           <div className="text-[#313B4A] text-justify font-montserrat text-base leading-relaxed">
-            {showSuggestionsExigenciasResponsabilidad ? (
-              <>
-                <p>
-                  Ejemplo: Puestos que conllevan una alta responsabilidad por la vida o seguridad de otros, por grandes cantidades de dinero, o por decisiones que tienen un impacto significativo en la organización.
-                </p>
-                <p className="font-semibold mt-2">Acciones de Intervención Sugeridas:</p>
-                <ol className="list-decimal ml-5 space-y-1">
-                  <li>
-                    Claridad en las Funciones y Límites de Responsabilidad: Asegurar una descripción clara del puesto y los límites de la responsabilidad.
-                  </li>
-                  <li>
-                    Sistemas de Apoyo y Consulta: Establecer mecanismos para que los trabajadores puedan consultar y recibir apoyo en la toma de decisiones críticas.
-                  </li>
-                  <li>
-                    Capacitación en Liderazgo y Toma de Decisiones: Desarrollar habilidades de liderazgo y toma de decisiones para manejar eficazmente la responsabilidad.
-                  </li>
-                  <li>
-                    Reconocimiento y Valoración: Implementar sistemas de reconocimiento para el manejo exitoso de responsabilidades, validando el esfuerzo y la presión.
-                  </li>
-                </ol>
-              </>
-            ) : (
+          {showSuggestionsExigenciasResponsabilidad ? (
+            <>
               <p>
-                El dominio evaluado se encuentra en un nivel óptimo, sin presencia significativa de riesgo. No se requieren acciones adicionales ni planes de mejora inmediatos; sin embargo, es importante continuar fortaleciendo las prácticas actuales para mantener estos resultados. ¡Felicitaciones por destacar en esta área y seguir siendo un ejemplo de excelencia!
+                Ejemplo: Puestos que conllevan una alta responsabilidad por la vida o seguridad de otros, por grandes cantidades de dinero, o por decisiones que tienen un impacto significativo en la organización.
               </p>
-            )}
+              <p className="font-semibold mt-2">Acciones de Intervención Sugeridas:</p>
+              <ol className="list-decimal ml-5 space-y-1">
+                <li>
+                  Claridad en las Funciones y Límites de Responsabilidad: Asegurar una descripción clara del puesto y los límites de la responsabilidad.
+                </li>
+                <li>
+                  Sistemas de Apoyo y Consulta: Establecer mecanismos para que los trabajadores puedan consultar y recibir apoyo en la toma de decisiones críticas.
+                </li>
+                <li>
+                  Capacitación en Liderazgo y Toma de Decisiones: Desarrollar habilidades de liderazgo y toma de decisiones para manejar eficazmente la responsabilidad.
+                </li>
+                <li>
+                  Reconocimiento y Valoración: Implementar sistemas de reconocimiento para el manejo exitoso de responsabilidades, validando el esfuerzo y la presión.
+                </li>
+              </ol>
+            </>
+          ) : (
+            <p>
+              El dominio evaluado se encuentra en un nivel óptimo, sin presencia significativa de riesgo. No se requieren acciones adicionales ni planes de mejora inmediatos; sin embargo, es importante continuar fortaleciendo las prácticas actuales para mantener estos resultados. ¡Felicitaciones por destacar en esta área y seguir siendo un ejemplo de excelencia!
+            </p>
+          )}
+        </div>
+      </div>
+      <RiskDistributionChart
+        title="Demandas cuantitativas Forma A y B"
+        data={demandasCuantitativasData}
+      />
+      <p className="mt-4 text-[#313B4A] text-justify font-montserrat text-base leading-relaxed">
+        Refieren la cantidad de trabajo que se debe realizar en relación con el tiempo disponible. Una alta demanda cuantitativa puede llevar a sobrecarga de trabajo y jornadas laborales extensas.
+      </p>
+      <p className="mt-4 text-[#313B4A] text-justify font-montserrat text-base leading-relaxed">
+        {demandasCuantitativasSentence}
+      </p>
+      <div className="mt-4 flex flex-col md:flex-row items-start gap-4">
+        <div className="flex flex-col items-center gap-4">
+          <div className="flex flex-col items-center">
+            <p className="font-semibold">Forma A</p>
+            <SemaphoreDial stage={stageDemandasCuantitativasA} />
+          </div>
+          <div className="flex flex-col items-center">
+            <p className="font-semibold">Forma B</p>
+            <SemaphoreDial stage={stageDemandasCuantitativasB} />
           </div>
         </div>
-      </TabsContent>
-        <TabsContent value="estrategias" />
-      </Tabs>
-    );
-  }
+        <div className="text-[#313B4A] text-justify font-montserrat text-base leading-relaxed">
+          {showSuggestionsDemandasCuantitativas ? (
+            <>
+              <p>
+                Ejemplo: Presión por cumplir plazos ajustados, gran volumen de tareas, necesidad de trabajar horas extras.
+              </p>
+              <p className="font-semibold mt-2">Acciones de Intervención Sugeridas:</p>
+              <ol className="list-decimal ml-5 space-y-1">
+                <li>
+                  Optimización de Cargas de Trabajo: Realizar estudios de carga laboral para asegurar una distribución equitativa y realista de las tareas.
+                </li>
+                <li>
+                  Gestión del Tiempo: Ofrecer capacitaciones en técnicas de gestión del tiempo y priorización de tareas.
+                </li>
+                <li>
+                  Dotación de Personal Suficiente: Evaluar la necesidad de contratar más personal o redistribuir responsabilidades para evitar la sobrecarga crónica.
+                </li>
+                <li>
+                  Definición Clara de Expectativas: Asegurar que los colaboradores comprendan las expectativas de desempeño y los plazos, fomentando la comunicación bidireccional
+                </li>
+              </ol>
+            </>
+          ) : (
+            <p>
+              El dominio evaluado se encuentra en un nivel óptimo, sin presencia significativa de riesgo. No se requieren acciones adicionales ni planes de mejora inmediatos; sin embargo, es importante continuar fortaleciendo las prácticas actuales para mantener estos resultados. ¡Felicitaciones por destacar en esta área y seguir siendo un ejemplo de excelencia!
+            </p>
+          )}
+        </div>
+      </div>
+    </TabsContent>
+      <TabsContent value="estrategias" />
+    </Tabs>
+  );
+}
 


### PR DESCRIPTION
## Summary
- compute and pass risk distribution data for Demandas cuantitativas
- add Demandas cuantitativas chart with description, dynamic text, and semaphores

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint found errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a39097d1148331aabf60b50580b98d