### PR TITLE
Add emotional demands chart to Gráficas report tab

### DIFF
--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -1113,6 +1113,66 @@ export default function DashboardResultados({
     return data;
   }, [datosA, datosB]);
 
+  const demandasEmocionalesData: RiskDistributionData = useMemo(() => {
+    const counts: Record<string, number> = {};
+    const countsA: Record<string, number> = {};
+    const countsB: Record<string, number> = {};
+    levelsOrder.forEach((lvl) => {
+      counts[lvl] = 0;
+      countsA[lvl] = 0;
+      countsB[lvl] = 0;
+    });
+    let invalid = 0;
+    let total = 0;
+    let totalA = 0;
+    let totalB = 0;
+    const nombre = "Demandas emocionales";
+    [...datosA, ...datosB].forEach((d) => {
+      let seccion: any =
+        d.resultadoFormaA?.dimensiones?.[nombre] ||
+        d.resultadoFormaB?.dimensiones?.[nombre];
+      if (!seccion && Array.isArray(d.resultadoFormaA?.dimensiones)) {
+        seccion = d.resultadoFormaA.dimensiones.find(
+          (x: any) => x.nombre === nombre
+        );
+      }
+      if (!seccion && Array.isArray(d.resultadoFormaB?.dimensiones)) {
+        seccion = d.resultadoFormaB.dimensiones.find(
+          (x: any) => x.nombre === nombre
+        );
+      }
+      const nivel = seccion?.nivel;
+      if (nivel) {
+        const base =
+          nivel === "Sin riesgo" ? "Muy bajo" : shortNivelRiesgo(nivel);
+        if (counts[base] !== undefined) {
+          counts[base] += 1;
+          if (d.tipo === "A") {
+            countsA[base] += 1;
+            totalA++;
+          } else {
+            countsB[base] += 1;
+            totalB++;
+          }
+          total++;
+        } else {
+          invalid++;
+        }
+      }
+    });
+    const data: RiskDistributionData = {
+      total,
+      counts,
+      levelsOrder: [...levelsOrder],
+      countsA,
+      countsB,
+      totalA,
+      totalB,
+    };
+    if (invalid > 0) data.invalid = invalid;
+    return data;
+  }, [datosA, datosB]);
+
   const demandasCuantitativasData: RiskDistributionData = useMemo(() => {
     const counts: Record<string, number> = {};
     const countsA: Record<string, number> = {};
@@ -2348,6 +2408,7 @@ export default function DashboardResultados({
                   controlDominioData={controlDominioData}
                   demandasDominioData={demandasDominioData}
                   demandasAmbientalesData={demandasAmbientalesData}
+                  demandasEmocionalesData={demandasEmocionalesData}
                   demandasCuantitativasData={demandasCuantitativasData}
                   influenciaTrabajoData={influenciaTrabajoData}
                   exigenciasResponsabilidadData={exigenciasResponsabilidadData}

--- a/src/components/dashboard/InformeTabs.tsx
+++ b/src/components/dashboard/InformeTabs.tsx
@@ -33,6 +33,7 @@ interface Props {
   controlDominioData: RiskDistributionData;
   demandasDominioData: RiskDistributionData;
   demandasAmbientalesData: RiskDistributionData;
+  demandasEmocionalesData: RiskDistributionData;
   demandasCuantitativasData: RiskDistributionData;
   influenciaTrabajoData: RiskDistributionData;
   exigenciasResponsabilidadData: RiskDistributionData;
@@ -60,6 +61,7 @@ export default function InformeTabs({
   controlDominioData,
   demandasDominioData,
   demandasAmbientalesData,
+  demandasEmocionalesData,
   demandasCuantitativasData,
   influenciaTrabajoData,
   exigenciasResponsabilidadData,
@@ -159,6 +161,13 @@ export default function InformeTabs({
     countsB: demandasAmbientalesData.countsB || {},
     totalA: demandasAmbientalesData.totalA || 0,
     totalB: demandasAmbientalesData.totalB || 0,
+  });
+  const demandasEmocionalesSentence = buildRiskSentence({
+    levelsOrder: demandasEmocionalesData.levelsOrder,
+    countsA: demandasEmocionalesData.countsA || {},
+    countsB: demandasEmocionalesData.countsB || {},
+    totalA: demandasEmocionalesData.totalA || 0,
+    totalB: demandasEmocionalesData.totalB || 0,
   });
   const influenciaTrabajoSentence = buildRiskSentence({
     levelsOrder: influenciaTrabajoData.levelsOrder,
@@ -313,6 +322,15 @@ export default function InformeTabs({
   const showSuggestionsDemandasAmbientales =
     stageDemandasAmbientalesA !== "primario" ||
     stageDemandasAmbientalesB !== "primario";
+  const stageDemandasEmocionalesA = demandasEmocionalesData.totalA
+    ? calcStage(demandasEmocionalesData.countsA || {})
+    : "primario";
+  const stageDemandasEmocionalesB = demandasEmocionalesData.totalB
+    ? calcStage(demandasEmocionalesData.countsB || {})
+    : "primario";
+  const showSuggestionsDemandasEmocionales =
+    stageDemandasEmocionalesA !== "primario" ||
+    stageDemandasEmocionalesB !== "primario";
   const stageInfluenciaTrabajoA = influenciaTrabajoData.totalA
     ? calcStage(influenciaTrabajoData.countsA || {})
     : "primario";
@@ -1476,6 +1494,56 @@ export default function InformeTabs({
                   </li>
                   <li>
                     Definición Clara de Expectativas: Asegurar que los colaboradores comprendan las expectativas de desempeño y los plazos, fomentando la comunicación bidireccional.
+                  </li>
+                </ol>
+              </>
+            ) : (
+              <p>
+                El dominio evaluado se encuentra en un nivel óptimo, sin presencia significativa de riesgo. No se requieren acciones adicionales ni planes de mejora inmediatos; sin embargo, es importante continuar fortaleciendo las prácticas actuales para mantener estos resultados. ¡Felicitaciones por destacar en esta área y seguir siendo un ejemplo de excelencia!
+              </p>
+            )}
+          </div>
+        </div>
+        <RiskDistributionChart
+          title="Demandas emocionales Forma A y B"
+          data={demandasEmocionalesData}
+        />
+        <p className="mt-4 text-[#313B4A] text-justify font-montserrat text-base leading-relaxed">
+          Refiere la exposición a situaciones emocionalmente exigentes, como el contacto con personas en crisis, violencia, o la necesidad de ocultar emociones.
+        </p>
+        <p className="mt-4 text-[#313B4A] text-justify font-montserrat text-base leading-relaxed">
+          {demandasEmocionalesSentence}
+        </p>
+        <div className="mt-4 flex flex-col md:flex-row items-start gap-4">
+          <div className="flex flex-col items-center gap-4">
+            <div className="flex flex-col items-center">
+              <p className="font-semibold">Forma A</p>
+              <SemaphoreDial stage={stageDemandasEmocionalesA} />
+            </div>
+            <div className="flex flex-col items-center">
+              <p className="font-semibold">Forma B</p>
+              <SemaphoreDial stage={stageDemandasEmocionalesB} />
+            </div>
+          </div>
+          <div className="text-[#313B4A] text-justify font-montserrat text-base leading-relaxed">
+            {showSuggestionsDemandasEmocionales ? (
+              <>
+                <p>
+                  Ejemplo: Trabajos que implican interacción con el público (clientes enojados, pacientes sufriendo), exposición a eventos traumáticos, o la necesidad de mantener una "fachada" emocional.
+                </p>
+                <p className="font-semibold mt-2">Acciones de Intervención Sugeridas:</p>
+                <ol className="list-decimal ml-5 space-y-1">
+                  <li>
+                    Apoyo Psicológico y Consulta: Establecer programas de apoyo psicológico o acceso a consulta para trabajadores expuestos a situaciones emocionalmente difíciles.
+                  </li>
+                  <li>
+                    Entrenamiento en Habilidades de Comunicación y Manejo de Conflictos: Capacitar al personal en el manejo de interacciones difíciles y resolución de conflictos.
+                  </li>
+                  <li>
+                    Debriefing Psicológico: Implementar sesiones de debriefing post-incidente para trabajadores expuestos a eventos traumáticos.
+                  </li>
+                  <li>
+                    Políticas de Respeto y No Violencia: Reforzar políticas internas que promuevan un ambiente de respeto y cero tolerancia a la violencia o el acoso
                   </li>
                 </ol>
               </>


### PR DESCRIPTION
## Summary
- compute emotional demands risk distribution in results dashboard
- expose emotional demands data to report tabs
- render emotional demands chart with risk text, semaphores, and suggestions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: @typescript-eslint errors in unrelated files)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a3964397108331be88f15d393c9915