### PR TITLE
feat: add pertenencia recompensas chart

### DIFF
--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -1651,6 +1651,66 @@ export default function DashboardResultados({
     if (invalid > 0) data.invalid = invalid;
     return data;
   }, [datosA, datosB]);
+  const recompensasPertenenciaData: RiskDistributionData = useMemo(() => {
+    const counts: Record<string, number> = {};
+    const countsA: Record<string, number> = {};
+    const countsB: Record<string, number> = {};
+    levelsOrder.forEach((lvl) => {
+      counts[lvl] = 0;
+      countsA[lvl] = 0;
+      countsB[lvl] = 0;
+    });
+    let invalid = 0;
+    let total = 0;
+    let totalA = 0;
+    let totalB = 0;
+    const nombre =
+      "Recompensas derivadas de la pertenencia a la organización y del trabajo que se realiza";
+    [...datosA, ...datosB].forEach((d) => {
+      let seccion: any =
+        d.resultadoFormaA?.dimensiones?.[nombre] ||
+        d.resultadoFormaB?.dimensiones?.[nombre];
+      if (!seccion && Array.isArray(d.resultadoFormaA?.dimensiones)) {
+        seccion = d.resultadoFormaA.dimensiones.find(
+          (x: any) => x.nombre === nombre
+        );
+      }
+      if (!seccion && Array.isArray(d.resultadoFormaB?.dimensiones)) {
+        seccion = d.resultadoFormaB.dimensiones.find(
+          (x: any) => x.nombre === nombre
+        );
+      }
+      const nivel = seccion?.nivel;
+      if (nivel) {
+        const base =
+          nivel === "Sin riesgo" ? "Muy bajo" : shortNivelRiesgo(nivel);
+        if (counts[base] !== undefined) {
+          counts[base] += 1;
+          if (d.tipo === "A") {
+            countsA[base] += 1;
+            totalA++;
+          } else {
+            countsB[base] += 1;
+            totalB++;
+          }
+          total++;
+        } else {
+          invalid++;
+        }
+      }
+    });
+    const data: RiskDistributionData = {
+      total,
+      counts,
+      levelsOrder: [...levelsOrder],
+      countsA,
+      countsB,
+      totalA,
+      totalB,
+    };
+    if (invalid > 0) data.invalid = invalid;
+    return data;
+  }, [datosA, datosB]);
   const reconocimientoCompensacionData: RiskDistributionData = useMemo(() => {
     const counts: Record<string, number> = {};
     const countsA: Record<string, number> = {};
@@ -2533,6 +2593,7 @@ export default function DashboardResultados({
                     demandasJornadaData={demandasJornadaData}
                     consistenciaRolData={consistenciaRolData}
                     recompensasDominioData={recompensasDominioData}
+                    recompensasPertenenciaData={recompensasPertenenciaData}
                     reconocimientoCompensacionData={reconocimientoCompensacionData}
                   />
             </section>

--- a/src/components/dashboard/InformeTabs.tsx
+++ b/src/components/dashboard/InformeTabs.tsx
@@ -41,6 +41,7 @@ interface Props {
   demandasJornadaData: RiskDistributionData;
   consistenciaRolData: RiskDistributionData;
   recompensasDominioData: RiskDistributionData;
+  recompensasPertenenciaData: RiskDistributionData;
   reconocimientoCompensacionData: RiskDistributionData;
 }
 
@@ -71,6 +72,7 @@ export default function InformeTabs({
   demandasJornadaData,
   consistenciaRolData,
   recompensasDominioData,
+  recompensasPertenenciaData,
   reconocimientoCompensacionData,
 }: Props) {
   const [value, setValue] = useState("introduccion");
@@ -215,20 +217,27 @@ export default function InformeTabs({
     totalA: consistenciaRolData.totalA || 0,
     totalB: consistenciaRolData.totalB || 0,
   });
-    const recompensasSentence = buildRiskSentence({
-      levelsOrder: recompensasDominioData.levelsOrder,
-      countsA: recompensasDominioData.countsA || {},
-      countsB: recompensasDominioData.countsB || {},
-      totalA: recompensasDominioData.totalA || 0,
-      totalB: recompensasDominioData.totalB || 0,
-    });
-    const reconocimientoCompensacionSentence = buildRiskSentence({
-      levelsOrder: reconocimientoCompensacionData.levelsOrder,
-      countsA: reconocimientoCompensacionData.countsA || {},
-      countsB: reconocimientoCompensacionData.countsB || {},
-      totalA: reconocimientoCompensacionData.totalA || 0,
-      totalB: reconocimientoCompensacionData.totalB || 0,
-    });
+  const recompensasSentence = buildRiskSentence({
+    levelsOrder: recompensasDominioData.levelsOrder,
+    countsA: recompensasDominioData.countsA || {},
+    countsB: recompensasDominioData.countsB || {},
+    totalA: recompensasDominioData.totalA || 0,
+    totalB: recompensasDominioData.totalB || 0,
+  });
+  const recompensasPertenenciaSentence = buildRiskSentence({
+    levelsOrder: recompensasPertenenciaData.levelsOrder,
+    countsA: recompensasPertenenciaData.countsA || {},
+    countsB: recompensasPertenenciaData.countsB || {},
+    totalA: recompensasPertenenciaData.totalA || 0,
+    totalB: recompensasPertenenciaData.totalB || 0,
+  });
+  const reconocimientoCompensacionSentence = buildRiskSentence({
+    levelsOrder: reconocimientoCompensacionData.levelsOrder,
+    countsA: reconocimientoCompensacionData.countsA || {},
+    countsB: reconocimientoCompensacionData.countsB || {},
+    totalA: reconocimientoCompensacionData.totalA || 0,
+    totalB: reconocimientoCompensacionData.totalB || 0,
+  });
 
   type Stage = "primario" | "secundario" | "terciario";
 
@@ -413,6 +422,15 @@ export default function InformeTabs({
     : "primario";
   const showSuggestionsRecompensas =
     stageRecompensasA !== "primario" || stageRecompensasB !== "primario";
+  const stageRecompensasPertenenciaA = recompensasPertenenciaData.totalA
+    ? calcStage(recompensasPertenenciaData.countsA || {})
+    : "primario";
+  const stageRecompensasPertenenciaB = recompensasPertenenciaData.totalB
+    ? calcStage(recompensasPertenenciaData.countsB || {})
+    : "primario";
+  const showSuggestionsRecompensasPertenencia =
+    stageRecompensasPertenenciaA !== "primario" ||
+    stageRecompensasPertenenciaB !== "primario";
   const stageReconocimientoCompensacionA =
     reconocimientoCompensacionData.totalA
       ? calcStage(reconocimientoCompensacionData.countsA || {})
@@ -1685,9 +1703,56 @@ export default function InformeTabs({
                 <p>
                   El dominio evaluado se encuentra en un nivel óptimo, sin presencia significativa de riesgo. No se requieren acciones adicionales ni planes de mejora inmediatos; sin embargo, es importante continuar fortaleciendo las prácticas actuales para mantener estos resultados. ¡Felicitaciones por destacar en esta área y seguir siendo un ejemplo de excelencia!
                 </p>
-              )}
+            )}
+          </div>
+        </div>
+        <RiskDistributionChart
+          title="Recompensas derivadas de la pertenencia a la organización Forma A y B"
+          data={recompensasPertenenciaData}
+        />
+        <p className="mt-4 text-[#313B4A] text-justify font-montserrat text-base leading-relaxed">
+          La compensación psicológica, que comprende el reconocimiento del grupo social y el trato justo en el trabajo
+        </p>
+        <p className="mt-4 text-[#313B4A] text-justify font-montserrat text-base leading-relaxed">
+          {recompensasPertenenciaSentence}
+        </p>
+        <div className="mt-4 flex flex-col md:flex-row items-start gap-4">
+          <div className="flex flex-col items-center gap-4">
+            <div className="flex flex-col items-center">
+              <p className="font-semibold">Forma A</p>
+              <SemaphoreDial stage={stageRecompensasPertenenciaA} />
+            </div>
+            <div className="flex flex-col items-center">
+              <p className="font-semibold">Forma B</p>
+              <SemaphoreDial stage={stageRecompensasPertenenciaB} />
             </div>
           </div>
+          <div className="text-[#313B4A] text-justify font-montserrat text-base leading-relaxed">
+            {showSuggestionsRecompensasPertenencia ? (
+              <>
+                <p>
+                  Ejemplo: Falta de reconocimiento por el esfuerzo o los logros, trato injusto o discriminación, falta de valoración por parte de superiores o compañeros.
+                </p>
+                <p className="font-semibold mt-2">Acciones de Intervención Sugeridas:</p>
+                <ol className="list-decimal ml-5 space-y-1">
+                  <li>
+                    Programas de Reconocimiento: Implementar programas formales e informales de reconocimiento de logros y buen desempeño (ej. empleado del mes, menciones en reuniones, cartas de agradecimiento).
+                  </li>
+                  <li>
+                    Fomentar una Cultura de Agradecimiento: Promover que los líderes y compañeros expresen aprecio por el trabajo de los demás.
+                  </li>
+                  <li>
+                    Políticas de Equidad y Trato Justo: Establecer políticas claras contra la discriminación y el trato injusto, y asegurar su cumplimiento.
+                  </li>
+                </ol>
+              </>
+            ) : (
+              <p>
+                El dominio evaluado se encuentra en un nivel óptimo, sin presencia significativa de riesgo. No se requieren acciones adicionales ni planes de mejora inmediatos; sin embargo, es importante continuar fortaleciendo las prácticas actuales para mantener estos resultados. ¡Felicitaciones por destacar en esta área y seguir siendo un ejemplo de excelencia!
+              </p>
+            )}
+          </div>
+        </div>
         </TabsContent>
           <TabsContent value="estrategias" />
         </Tabs>


### PR DESCRIPTION
## Summary
- compute risk distribution for Recompensas derivadas de la pertenencia a la organización
- display new chart and semaphores with recommendations in Graficas tab

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 123 problems (98 errors, 25 warnings))*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a39b859d7483318c1218d3a3d3ca78