### PR TITLE
feat: add economic situation extralaboral chart

### DIFF
--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -1976,6 +1976,60 @@ export default function DashboardResultados({
     if (invalid > 0) data.invalid = invalid;
     return data;
   }, [datosExtra]);
+  const situacionEconomicaData: RiskDistributionData = useMemo(() => {
+    const counts: Record<string, number> = {};
+    const countsA: Record<string, number> = {};
+    const countsB: Record<string, number> = {};
+    levelsOrder.forEach((lvl) => {
+      counts[lvl] = 0;
+      countsA[lvl] = 0;
+      countsB[lvl] = 0;
+    });
+    let invalid = 0;
+    let total = 0;
+    let totalA = 0;
+    let totalB = 0;
+    const nombre = "Situación económica del grupo familiar";
+    datosExtra.forEach((d) => {
+      let seccion: any = (d.resultadoExtralaboral as any)?.dimensiones?.[
+        nombre as any
+      ];
+      if (Array.isArray(d.resultadoExtralaboral?.dimensiones)) {
+        seccion = d.resultadoExtralaboral.dimensiones.find(
+          (x) => x.nombre === nombre
+        );
+      }
+      const nivel = seccion?.nivel;
+      if (nivel) {
+        const base =
+          nivel === "Sin riesgo" ? "Muy bajo" : shortNivelRiesgo(nivel);
+        if (counts[base] !== undefined) {
+          counts[base] += 1;
+          if (d.tipo === "A") {
+            countsA[base] += 1;
+            totalA++;
+          } else {
+            countsB[base] += 1;
+            totalB++;
+          }
+          total++;
+        } else {
+          invalid++;
+        }
+      }
+    });
+    const data: RiskDistributionData = {
+      total,
+      counts,
+      levelsOrder: [...levelsOrder],
+      countsA,
+      countsB,
+      totalA,
+      totalB,
+    };
+    if (invalid > 0) data.invalid = invalid;
+    return data;
+  }, [datosExtra]);
   const ciudadInforme =
     datosMostrados.find((d) => d.ficha?.trabajoCiudad)?.ficha?.trabajoCiudad || "";
 
@@ -2806,6 +2860,7 @@ export default function DashboardResultados({
                     tiempoFueraTrabajoData={tiempoFueraTrabajoData}
                     relacionesFamiliaresData={relacionesFamiliaresData}
                     comunicacionRelacionesData={comunicacionRelacionesData}
+                    situacionEconomicaData={situacionEconomicaData}
                   />
             </section>
           </div>

--- a/src/components/dashboard/InformeTabs.tsx
+++ b/src/components/dashboard/InformeTabs.tsx
@@ -47,6 +47,7 @@ interface Props {
   tiempoFueraTrabajoData: RiskDistributionData;
   relacionesFamiliaresData: RiskDistributionData;
   comunicacionRelacionesData: RiskDistributionData;
+  situacionEconomicaData: RiskDistributionData;
 }
 
 export default function InformeTabs({
@@ -82,6 +83,7 @@ export default function InformeTabs({
   tiempoFueraTrabajoData,
   relacionesFamiliaresData,
   comunicacionRelacionesData,
+  situacionEconomicaData,
 }: Props) {
   const [value, setValue] = useState("introduccion");
   const intro = buildIntroduccion(introduccionData);
@@ -273,6 +275,13 @@ export default function InformeTabs({
     countsB: comunicacionRelacionesData.countsB || {},
     totalA: comunicacionRelacionesData.totalA || 0,
     totalB: comunicacionRelacionesData.totalB || 0,
+  });
+  const situacionEconomicaSentence = buildRiskSentence({
+    levelsOrder: situacionEconomicaData.levelsOrder,
+    countsA: situacionEconomicaData.countsA || {},
+    countsB: situacionEconomicaData.countsB || {},
+    totalA: situacionEconomicaData.totalA || 0,
+    totalB: situacionEconomicaData.totalB || 0,
   });
 
   type Stage = "primario" | "secundario" | "terciario";
@@ -513,6 +522,15 @@ export default function InformeTabs({
   const showSuggestionsComunicacionRelaciones =
     stageComunicacionRelacionesA !== "primario" ||
     stageComunicacionRelacionesB !== "primario";
+  const stageSituacionEconomicaA = situacionEconomicaData.totalA
+    ? calcStage(situacionEconomicaData.countsA || {})
+    : "primario";
+  const stageSituacionEconomicaB = situacionEconomicaData.totalB
+    ? calcStage(situacionEconomicaData.countsB || {})
+    : "primario";
+  const showSuggestionsSituacionEconomica =
+    stageSituacionEconomicaA !== "primario" ||
+    stageSituacionEconomicaB !== "primario";
   return (
     <Tabs value={value} onValueChange={setValue} className="w-full">
       <TabsList className="mb-6 py-2 px-4 scroll-pl-4 w-full flex gap-2 overflow-x-auto whitespace-nowrap">
@@ -2010,6 +2028,53 @@ export default function InformeTabs({
                   </li>
                   <li>
                     Información sobre Recursos Comunitarios: Proporcionar información sobre recursos o actividades comunitarias que puedan facilitar la socialización y la construcción de redes de apoyo.
+                  </li>
+                </ol>
+              </>
+            ) : (
+              <p>
+                El dominio evaluado se encuentra en un nivel óptimo, sin presencia significativa de riesgo. No se requieren acciones adicionales ni planes de mejora inmediatos; sin embargo, es importante continuar fortaleciendo las prácticas actuales para mantener estos resultados. ¡Felicitaciones por destacar en esta área y seguir siendo un ejemplo de excelencia!
+              </p>
+            )}
+          </div>
+        </div>
+        <RiskDistributionChart
+          title="Situación económica del grupo familiar Forma A y B"
+          data={situacionEconomicaData}
+        />
+        <p className="mt-4 text-[#313B4A] text-justify font-montserrat text-base leading-relaxed">
+          Refiere Percepción de estabilidad económica y suficiencia de ingresos para cubrir las necesidades básicas de la familia.
+        </p>
+        <p className="mt-4 text-[#313B4A] text-justify font-montserrat text-base leading-relaxed">
+          {situacionEconomicaSentence}
+        </p>
+        <div className="mt-4 flex flex-col md:flex-row items-start gap-4">
+          <div className="flex flex-col items-center gap-4">
+            <div className="flex flex-col items-center">
+              <p className="font-semibold">Forma A</p>
+              <SemaphoreDial stage={stageSituacionEconomicaA} />
+            </div>
+            <div className="flex flex-col items-center">
+              <p className="font-semibold">Forma B</p>
+              <SemaphoreDial stage={stageSituacionEconomicaB} />
+            </div>
+          </div>
+          <div className="text-[#313B4A] text-justify font-montserrat text-base leading-relaxed">
+            {showSuggestionsSituacionEconomica ? (
+              <>
+                <p>
+                  Ejemplo: Preocupaciones financieras, deudas, inseguridad económica que generan estrés y ansiedad.
+                </p>
+                <p className="font-semibold mt-2">Acciones de Intervención Sugeridas:</p>
+                <ol className="list-decimal ml-5 space-y-1">
+                  <li>
+                    Programas de Educación Financiera: Ofrecer talleres sobre manejo de finanzas personales, presupuesto, ahorro e inversión para empoderar a los empleados en la gestión de su economía.
+                  </li>
+                  <li>
+                    Acceso a Beneficios y Asesorías: Informar sobre beneficios corporativos (planes de ahorro, auxilios) o convenios con entidades financieras que puedan ofrecer condiciones ventajosas.
+                  </li>
+                  <li>
+                    Políticas Salariales Justas: Asegurar que la política de remuneración sea competitiva y justa, revisando periódicamente las estructuras salariales.
                   </li>
                 </ol>
               </>


### PR DESCRIPTION
## Summary
- add chart for *Situación económica del grupo familiar* in extralaboral section with narrative, semaphores and suggestions
- compute and pass distribution data for economic situation dimension

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 140 problems)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3bb52b3d083319bbeb502c1822be9