### PR TITLE
feat: show compact general results cards

### DIFF
--- a/src/components/ResultadosGeneralesCards.tsx
+++ b/src/components/ResultadosGeneralesCards.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+
+export interface ResultadosGeneralesItem {
+  key: string;
+  label: string;
+  level: "PRIMARIO" | "SECUNDARIO" | "TERCIARIO";
+}
+
+interface Props {
+  items: ResultadosGeneralesItem[];
+  onSelect?: (item: ResultadosGeneralesItem) => void;
+  compact?: boolean;
+}
+
+const LEVEL_STYLES: Record<
+  ResultadosGeneralesItem["level"],
+  { bg: string; accent: string; text: string }
+> = {
+  PRIMARIO: { bg: "#86EFAC", accent: "#16A34A", text: "#0F172A" },
+  SECUNDARIO: { bg: "#FDE68A", accent: "#F59E0B", text: "#0F172A" },
+  TERCIARIO: { bg: "#FCA5A5", accent: "#DC2626", text: "#FFFFFF" },
+};
+
+export default function ResultadosGeneralesCards({
+  items,
+  onSelect,
+  compact = false,
+}: Props) {
+  const handleSelect = (item: ResultadosGeneralesItem) => {
+    onSelect?.(item);
+  };
+  const cols = Math.min(items.length, 4);
+  return (
+    <div
+      className="grid gap-4 sm:grid-cols-2"
+      style={{ gridTemplateColumns: `repeat(${cols}, minmax(0,1fr))` }}
+    >
+      {items.map((item) => {
+        const styles = LEVEL_STYLES[item.level];
+        const padding = compact ? "p-3" : "p-4";
+        const labelSize = compact ? "text-xs" : "text-sm";
+        const levelSize = compact ? "text-sm" : "text-lg";
+        return (
+          <button
+            key={item.key}
+            type="button"
+            aria-label={`${item.label} – ${item.level}`}
+            onClick={() => handleSelect(item)}
+            className={`rounded-2xl shadow-sm ${padding} min-h-[72px] flex flex-col items-center justify-center text-center border transition hover:shadow-md hover:-translate-y-0.5 cursor-pointer`}
+            style={{
+              backgroundColor: styles.bg,
+              borderColor: `${styles.accent}4D`,
+              color: styles.text,
+            }}
+            title={item.level}
+          >
+            <span className={`font-semibold uppercase ${labelSize} mb-1`}>
+              {item.label}
+            </span>
+            <span className={`${levelSize} font-bold truncate`}>{item.level}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+

--- a/src/components/dashboard/InformeTabs.tsx
+++ b/src/components/dashboard/InformeTabs.tsx
@@ -13,6 +13,9 @@ import Generalidades from "./Generalidades";
 import Metodologia from "./Metodologia";
 import { buildRiskSentence } from "@/utils/riskSentence";
 import SemaphoreDial from "@/components/SemaphoreDial";
+import ResultadosGeneralesCards, {
+  type ResultadosGeneralesItem,
+} from "@/components/ResultadosGeneralesCards";
 
 interface Props {
   tabClass: string;
@@ -648,6 +651,41 @@ export default function InformeTabs({
     const stageIntralaboralTotalB = intralaboralTotalData.totalB
       ? calcStage(intralaboralTotalData.countsB || {})
       : "primario";
+    const stageFactorEstres = factorEstresData.total
+      ? calcStage(factorEstresData.counts || {})
+      : "primario";
+    const stageExtralaboral = extralaboralData.total
+      ? calcStage(extralaboralData.counts || {})
+      : "primario";
+    const generalItems: ResultadosGeneralesItem[] = [];
+    if (intralaboralTotalData.totalA) {
+      generalItems.push({
+        key: "formaA",
+        label: "Forma A",
+        level: stageIntralaboralTotalA.toUpperCase() as ResultadosGeneralesItem["level"],
+      });
+    }
+    if (intralaboralTotalData.totalB) {
+      generalItems.push({
+        key: "formaB",
+        label: "Forma B",
+        level: stageIntralaboralTotalB.toUpperCase() as ResultadosGeneralesItem["level"],
+      });
+    }
+    if (factorEstresData.total) {
+      generalItems.push({
+        key: "estres",
+        label: "Estrés",
+        level: stageFactorEstres.toUpperCase() as ResultadosGeneralesItem["level"],
+      });
+    }
+    if (extralaboralData.total) {
+      generalItems.push({
+        key: "extra",
+        label: "Extralaboral",
+        level: stageExtralaboral.toUpperCase() as ResultadosGeneralesItem["level"],
+      });
+    }
     const showSuggestionsFactorEstres =
       stageFactorEstresA !== "primario" || stageFactorEstresB !== "primario";
     return (
@@ -2522,7 +2560,22 @@ export default function InformeTabs({
             </div>
           </div>
         </TabsContent>
-        <TabsContent value="estrategias" />
+        <TabsContent value="estrategias">
+          <ResultadosGeneralesCards
+            items={generalItems}
+            onSelect={(item) => console.log(item)}
+          />
+          <div className="mt-6 space-y-2">
+            <p className="font-semibold">CONCLUSIONES:</p>
+            <p>
+              De acuerdo a resultados analizados se evidencian riesgos ALTOS Y MUY
+              ALTOS, en las siguientes dimensiones por lo que se sugiere Realizar un
+              programa de Vigilancia epidemiológico por Riesgo psicosocial y tener en
+              cuenta las recomendaciones y sugerencias establecidas en este diagnóstico
+              para las siguientes categorías:
+            </p>
+          </div>
+        </TabsContent>
         </Tabs>
       );
   }


### PR DESCRIPTION
## Summary
- add reusable `ResultadosGeneralesCards` to display risk levels as colored cards
- compute overall stages and render general results cards in Estrategias tab of report
- add concluding note below general results cards in Estrategias tab

## Testing
- `npm run lint` *(fails: existing lint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3d8c701348331b9bfa74e4dd1b640