### PR TITLE
feat: add informative accordion for work demands domain

### DIFF
--- a/src/components/AccordionItem.tsx
+++ b/src/components/AccordionItem.tsx
@@ -1,0 +1,41 @@
+import { useState, type ReactNode } from "react";
+import { ChevronDown } from "lucide-react";
+
+interface AccordionItemProps {
+  id: string;
+  title: string;
+  children: ReactNode;
+}
+
+export default function AccordionItem({ id, title, children }: AccordionItemProps) {
+  const [open, setOpen] = useState(false);
+  const contentId = `${id}-content`;
+
+  return (
+    <div className="rounded-2xl border border-slate-200 shadow-sm bg-white">
+      <button
+        id={id}
+        type="button"
+        aria-expanded={open}
+        aria-controls={contentId}
+        onClick={() => setOpen((prev) => !prev)}
+        className="w-full flex items-center justify-between px-4 py-3 text-left font-semibold text-[#313B4A]"
+      >
+        {title}
+        <ChevronDown
+          className={`h-5 w-5 transition-transform ${open ? "rotate-180" : ""}`}
+          aria-hidden="true"
+        />
+      </button>
+      <div
+        id={contentId}
+        role="region"
+        aria-labelledby={id}
+        className={open ? "block" : "hidden"}
+      >
+        <div className="px-4 pb-4">{children}</div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/TablaInformativa.tsx
+++ b/src/components/TablaInformativa.tsx
@@ -1,0 +1,50 @@
+interface Row {
+  dimension: string;
+  acciones: string[];
+}
+
+interface TablaInformativaProps {
+  headers: [string, string];
+  rows: Row[];
+  exportMode?: boolean;
+}
+
+export default function TablaInformativa({ headers, rows, exportMode = false }: TablaInformativaProps) {
+  const containerClasses = `rounded-2xl bg-white ${exportMode ? "shadow-none" : "shadow-sm"} p-4 md:p-6 font-montserrat text-[#172349]`;
+
+  return (
+    <div className={containerClasses}>
+      <table className="w-full text-left border-collapse">
+        <thead className="bg-primary-main text-white font-semibold">
+          <tr>
+            <th scope="col" className="py-2 px-3">{headers[0]}</th>
+            <th scope="col" className="py-2 px-3">{headers[1]}</th>
+          </tr>
+        </thead>
+        <tbody className="block md:table-row-group">
+          {rows.map((row, idx) => (
+            <tr
+              key={row.dimension}
+              className={`block md:table-row border-b border-slate-100 ${idx % 2 === 1 ? "bg-slate-50" : ""} ${!exportMode ? "hover:bg-slate-50" : ""}`}
+            >
+              <th
+                scope="row"
+                className="block md:table-cell font-semibold px-3 py-3 align-top md:w-1/3"
+              >
+                {row.dimension}
+              </th>
+              <td className="block md:table-cell px-3 py-3">
+                <ul role="list" className="list-disc pl-5 space-y-1">
+                  {row.acciones.map((accion, i) => (
+                    <li key={i}>{accion}</li>
+                  ))}
+                </ul>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+

--- a/src/components/dashboard/InformeTabs.tsx
+++ b/src/components/dashboard/InformeTabs.tsx
@@ -17,6 +17,8 @@ import ResultadosGeneralesCards, {
   type ResultadosGeneralesItem,
 } from "@/components/ResultadosGeneralesCards";
 import CuadroAreasDeMejora from "@/components/CuadroAreasDeMejora";
+import AccordionItem from "@/components/AccordionItem";
+import TablaInformativa from "@/components/TablaInformativa";
 import { esquemaFormaA } from "@/data/esquemaFormaA";
 import { esquemaFormaB } from "@/data/esquemaFormaB";
 import { shortNivelRiesgo } from "@/utils/shortNivelRiesgo";
@@ -2667,6 +2669,39 @@ export default function InformeTabs({
           </div>
           <div className="mt-6">
             <CuadroAreasDeMejora data={areasMejoraData} />
+          </div>
+          <div className="mt-6">
+            <AccordionItem
+              id="dominio-demandas-del-trabajo-cont"
+              title="Cont. Dominio demandas del trabajo"
+            >
+              <TablaInformativa
+                headers={[
+                  "Dimensión psicosocial",
+                  "Acciones de promoción e intervención",
+                ]}
+                rows={[
+                  {
+                    dimension: "Consistencia de rol",
+                    acciones: [
+                      "Inducción y reinducción.",
+                      "Claridad de rol como pilar del desempeño.",
+                      "Servicio de asistencia al trabajador.",
+                      "Mejoramiento participativo de las condiciones psicosociales de trabajo.",
+                    ],
+                  },
+                  {
+                    dimension: "Demandas de la jornada de trabajo",
+                    acciones: [
+                      "Gestión del trabajo por turnos.",
+                      "Gestión de las pausas en el trabajo.",
+                      "Mejoramiento participativo de las condiciones psicosociales de trabajo.",
+                    ],
+                  },
+                ]}
+                exportMode={false}
+              />
+            </AccordionItem>
           </div>
           <div className="mt-6 space-y-2 text-[#313B4A] text-justify font-montserrat text-base leading-relaxed">
             <p className="font-semibold">Recomendaciones:</p>


### PR DESCRIPTION
## Summary
- add reusable AccordionItem component
- add TablaInformativa component for fixed dimension/action table
- insert "Cont. Dominio demandas del trabajo" accordion with informative table in Estrategias tab

## Testing
- `npm test` (fails: Missing script: test)
- `npm run lint` (fails: unexpected any etc.)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7ebbe8054833199c386db84bd146d