### PR TITLE
refactor: control accordion state from parent

### DIFF
--- a/src/components/AccordionItem.tsx
+++ b/src/components/AccordionItem.tsx
@@ -1,14 +1,21 @@
-import { useState, type ReactNode } from "react";
+import type { ReactNode } from "react";
 import { ChevronDown } from "lucide-react";
 
 interface AccordionItemProps {
   id: string;
   title: string;
   children: ReactNode;
+  isOpen: boolean;
+  onToggle: () => void;
 }
 
-export default function AccordionItem({ id, title, children }: AccordionItemProps) {
-  const [open, setOpen] = useState(false);
+export default function AccordionItem({
+  id,
+  title,
+  children,
+  isOpen,
+  onToggle,
+}: AccordionItemProps) {
   const contentId = `${id}-content`;
 
   return (
@@ -16,14 +23,14 @@ export default function AccordionItem({ id, title, children }: AccordionItemProp
       <button
         id={id}
         type="button"
-        aria-expanded={open}
+        aria-expanded={isOpen}
         aria-controls={contentId}
-        onClick={() => setOpen((prev) => !prev)}
+        onClick={onToggle}
         className="w-full flex items-center justify-between px-4 py-3 text-left font-semibold text-[#313B4A]"
       >
         {title}
         <ChevronDown
-          className={`h-5 w-5 transition-transform ${open ? "rotate-180" : ""}`}
+          className={`h-5 w-5 transition-transform ${isOpen ? "rotate-180" : ""}`}
           aria-hidden="true"
         />
       </button>
@@ -31,7 +38,7 @@ export default function AccordionItem({ id, title, children }: AccordionItemProp
         id={contentId}
         role="region"
         aria-labelledby={id}
-        className={open ? "block" : "hidden"}
+        className={isOpen ? "block" : "hidden"}
       >
         <div className="px-4 pb-4">{children}</div>
       </div>

--- a/src/components/dashboard/InformeTabs.tsx
+++ b/src/components/dashboard/InformeTabs.tsx
@@ -105,6 +105,9 @@ export default function InformeTabs({
   factorEstresData,
 }: Props) {
   const [value, setValue] = useState("introduccion");
+  const [activeItem, setActiveItem] = useState<string | null>(null);
+  const handleToggle = (id: string) =>
+    setActiveItem((prev) => (prev === id ? null : id));
   const intro = buildIntroduccion(introduccionData);
   const dominioSentence = buildRiskSentence({
     levelsOrder: liderazgoDominioData.levelsOrder,
@@ -2674,6 +2677,8 @@ export default function InformeTabs({
             <AccordionItem
               id="dominio-demandas-del-trabajo-cont"
               title="Cont. Dominio demandas del trabajo"
+              isOpen={activeItem === "dominio-demandas-del-trabajo-cont"}
+              onToggle={() => handleToggle("dominio-demandas-del-trabajo-cont")}
             >
               <TablaInformativa
                 headers={[
@@ -2705,6 +2710,8 @@ export default function InformeTabs({
             <AccordionItem
               id="dominio-recompensas-cont"
               title="Cont. Dominio recompensas"
+              isOpen={activeItem === "dominio-recompensas-cont"}
+              onToggle={() => handleToggle("dominio-recompensas-cont")}
             >
               <TablaInformativa
                 headers={[
@@ -2740,6 +2747,8 @@ export default function InformeTabs({
             <AccordionItem
               id="dominio-liderazgo-relaciones-cont"
               title="Cont. Dominio características de liderazgo y relaciones sociales"
+              isOpen={activeItem === "dominio-liderazgo-relaciones-cont"}
+              onToggle={() => handleToggle("dominio-liderazgo-relaciones-cont")}
             >
               <TablaInformativa
                 headers={[
@@ -2796,6 +2805,8 @@ export default function InformeTabs({
             <AccordionItem
               id="factores-extralaborales-cont"
               title="Cont. Factores psicosociales extralaborales"
+              isOpen={activeItem === "factores-extralaborales-cont"}
+              onToggle={() => handleToggle("factores-extralaborales-cont")}
             >
               <TablaInformativa
                 headers={[
@@ -2867,6 +2878,8 @@ export default function InformeTabs({
             <AccordionItem
               id="efectos-riesgo-psicosocial-cont"
               title="Cont. Efectos de los factores de riesgo psicosocial"
+              isOpen={activeItem === "efectos-riesgo-psicosocial-cont"}
+              onToggle={() => handleToggle("efectos-riesgo-psicosocial-cont")}
             >
               <TablaInformativa
                 headers={[
@@ -2923,6 +2936,8 @@ export default function InformeTabs({
             <AccordionItem
               id="efectos-riesgo-psicosocial-cont-2"
               title="Cont. Efectos de los factores de riesgo psicosocial"
+              isOpen={activeItem === "efectos-riesgo-psicosocial-cont-2"}
+              onToggle={() => handleToggle("efectos-riesgo-psicosocial-cont-2")}
             >
               <TablaInformativa
                 headers={[


### PR DESCRIPTION
## Summary
- make `AccordionItem` controlled via `isOpen` and `onToggle`
- handle active accordion item within `InformeTabs` estrategias section

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: eslint found problems)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f929cc0483319261eebe41a73848