### PR TITLE
fix: import TablaDimensionesExtralaborales component

### DIFF
--- a/src/components/dashboard/InformeTabs.tsx
+++ b/src/components/dashboard/InformeTabs.tsx
@@ -21,6 +21,7 @@ import AccordionItem from "@/components/AccordionItem";
 import CartaCustodiaSST from "@/components/CartaCustodiaSST";
 import TablaInformativa from "@/components/TablaInformativa";
 import TablaConstructosVariables from "@/components/TablaConstructosVariables";
+import TablaDimensionesExtralaborales from "@/components/TablaDimensionesExtralaborales";
 import { esquemaFormaA } from "@/data/esquemaFormaA";
 import { esquemaFormaB } from "@/data/esquemaFormaB";
 import { shortNivelRiesgo } from "@/utils/shortNivelRiesgo";


### PR DESCRIPTION
## Summary
- fix missing import for TablaDimensionesExtralaborales in InformeTabs, resolving TS2304

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 155 problems (120 errors, 35 warnings))
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a804f57c7c83319752d46d916aed00