### PR TITLE
fix: import TablaSintomasEstres in InformeTabs

### DIFF
--- a/src/components/dashboard/InformeTabs.tsx
+++ b/src/components/dashboard/InformeTabs.tsx
@@ -22,6 +22,7 @@ import CartaCustodiaSST from "@/components/CartaCustodiaSST";
 import TablaInformativa from "@/components/TablaInformativa";
 import TablaConstructosVariables from "@/components/TablaConstructosVariables";
 import TablaDimensionesExtralaborales from "@/components/TablaDimensionesExtralaborales";
+import TablaSintomasEstres from "@/components/TablaSintomasEstres";
 import TablaTiposRiesgo from "@/components/TablaTiposRiesgo";
 import { esquemaFormaA } from "@/data/esquemaFormaA";
 import { esquemaFormaB } from "@/data/esquemaFormaB";


### PR DESCRIPTION
## Summary
- add missing TablaSintomasEstres import in InformeTabs so stress questionnaire tab renders

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 120 errors, 35 warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a809aac47883318a0c6c54d6444c86