### PR TITLE
feat: ensure DOM paint before PDF export

### DIFF
--- a/src/hooks/usePdfExport.ts
+++ b/src/hooks/usePdfExport.ts
@@ -10,7 +10,12 @@ export function usePdfExport() {
   async function exportNow(filename: string) {
     setRendering(true);
     setProgress("Montando informe…");
-    await new Promise((r) => setTimeout(r, 350)); // dejar que React pinte
+    // Usamos un doble requestAnimationFrame para esperar al siguiente
+    // ciclo de pintado y confirmar que el DOM se actualizó tras los
+    // cambios de estado.
+    await new Promise<void>((resolve) =>
+      requestAnimationFrame(() => requestAnimationFrame(resolve))
+    );
     try {
       if (ref.current) {
         await exportElementToPDF(ref.current, filename, {


### PR DESCRIPTION
## Summary
- replace timeout delay with double `requestAnimationFrame` to wait for DOM paint before exporting PDF
- document the DOM paint synchronization strategy

## Testing
- `npm run lint` *(fails: nivelesRiesgo unused, Unexpected any, analytics unused, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a80a9815c0833199cee9caf6e69832