### PR TITLE
feat: handle circular refs in removeUndefined

### DIFF
--- a/src/utils/removeUndefined.ts
+++ b/src/utils/removeUndefined.ts
@@ -1,20 +1,53 @@
-export function removeUndefined<T>(obj: T): T {
-  if (Array.isArray(obj)) {
-    return obj
-      .filter((v) => v !== undefined)
-      .map((v) => removeUndefined(v)) as unknown as T;
-  } else if (obj && typeof obj === "object") {
-    const result: any = {};
-    Object.entries(obj as any).forEach(([key, value]) => {
-      if (value !== undefined) {
-        const cleaned = removeUndefined(value);
-        if (cleaned !== undefined) {
-          result[key] = cleaned;
-        }
+/**
+ * Recursively removes properties with `undefined` values from objects and arrays.
+ *
+ * Circular references are detected using a {@link WeakSet} to avoid infinite
+ * recursion. The maximum depth of the traversal can be controlled via the
+ * `maxDepth` option; by default the depth is unlimited.
+ *
+ * When the maximum depth is reached or a circular reference is encountered,
+ * the value is returned as-is without further traversal.
+ *
+ * @param obj - Value to clean of `undefined` entries.
+ * @param options - Optional settings for the operation.
+ * @param options.maxDepth - Maximum recursion depth. Defaults to `Infinity`.
+ */
+export function removeUndefined<T>(
+  obj: T,
+  options: { maxDepth?: number } = {},
+): T {
+  const { maxDepth = Infinity } = options;
+  const seen = new WeakSet<object>();
+
+  const helper = (value: unknown, depth: number): unknown => {
+    if (value && typeof value === "object") {
+      if (seen.has(value as object)) {
+        return value;
       }
-    });
-    return result;
-  }
-  return obj;
+      if (depth >= maxDepth) {
+        return value;
+      }
+      seen.add(value as object);
+      if (Array.isArray(value)) {
+        return (value as unknown[])
+          .filter((v) => v !== undefined)
+          .map((v) => helper(v, depth + 1));
+      }
+      const result: Record<string, unknown> = {};
+      Object.entries(value as Record<string, unknown>).forEach(([key, v]) => {
+        if (v !== undefined) {
+          const cleaned = helper(v, depth + 1);
+          if (cleaned !== undefined) {
+            result[key] = cleaned;
+          }
+        }
+      });
+      return result;
+    }
+    return value;
+  };
+
+  return helper(obj, 0) as T;
 }
+
 export default removeUndefined;


### PR DESCRIPTION
## Summary
- detect circular references in removeUndefined using a WeakSet
- add optional maxDepth control and document expected behavior

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: 153 problems)

------
https://chatgpt.com/codex/tasks/task_e_68a80a7d20cc8331aa6bba7c9ab77e55