### PR TITLE
refactor: replace alerts with toast and remove debug logs

### DIFF
--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -2723,12 +2723,6 @@ export default function DashboardResultados({
     hallazgosClave: hallazgos,
   });
 
-  useEffect(() => {
-    console.log("ReportPayload", reportPayload);
-    console.log("Recomendaciones →", recomendaciones);
-    console.log("Conclusiones →", conclusiones);
-  }, [reportPayload, recomendaciones, conclusiones]);
-
   async function onGenerarInformePDF() {
     const fn = `Informe_${reportPayload.empresa.nombre}_${new Date(
       reportPayload.fechaInformeISO

--- a/src/components/dashboard/InformeTabs.tsx
+++ b/src/components/dashboard/InformeTabs.tsx
@@ -2636,10 +2636,7 @@ export default function InformeTabs({
           </div>
         </TabsContent>
         <TabsContent value="estrategias">
-          <ResultadosGeneralesCards
-            items={generalItems}
-            onSelect={(item) => console.log(item)}
-          />
+          <ResultadosGeneralesCards items={generalItems} />
           <div className="mt-6 space-y-2">
             <p className="font-semibold">CONCLUSIONES:</p>
             <p>

--- a/src/hooks/useCredenciales.ts
+++ b/src/hooks/useCredenciales.ts
@@ -10,6 +10,7 @@ import {
 import { db } from "../firebaseConfig";
 import { CredencialEmpresa } from "../types";
 import { demoCredencialesConst } from "../data/demoCredenciales";
+import { toast } from "../utils/toast";
 
 export default function useCredenciales() {
   const demoCredenciales: (CredencialEmpresa & { rol: string })[] = JSON.parse(
@@ -76,7 +77,7 @@ export default function useCredenciales() {
       return true;
     } catch (err) {
       console.error("Error al agregar empresa", err);
-      alert("No se pudo agregar la empresa");
+      toast("No se pudo agregar la empresa");
       return false;
     }
   };
@@ -90,7 +91,7 @@ export default function useCredenciales() {
       return true;
     } catch (err) {
       console.error("Error al eliminar empresa", err);
-      alert("No se pudo eliminar la empresa");
+      toast("No se pudo eliminar la empresa");
       return false;
     }
   };
@@ -119,7 +120,7 @@ export default function useCredenciales() {
       return true;
     } catch (err) {
       console.error("Error al editar empresa", err);
-      alert("No se pudo editar la empresa");
+      toast("No se pudo editar la empresa");
       return false;
     }
   };

--- a/src/services/resultService.ts
+++ b/src/services/resultService.ts
@@ -16,6 +16,7 @@ import {
   calcularGlobalBExtrala,
 } from "../utils/calcularGlobalA";
 import removeUndefined from "../utils/removeUndefined";
+import { toast } from "../utils/toast";
 
 interface Params {
   ficha: FichaDatos | null;
@@ -84,7 +85,7 @@ export async function guardarResultados({
     await addDoc(collection(db, "resultadosCogent"), cleanData);
   } catch (err) {
     console.error("Error al guardar resultados", err);
-    alert("No se pudieron guardar los resultados");
+    toast("No se pudieron guardar los resultados");
   }
 
   return { resultadoForma, resultadoGlobal };

--- a/src/utils/handleError.ts
+++ b/src/utils/handleError.ts
@@ -1,4 +1,10 @@
-export function handleError(error: unknown, logMessage: string, alertMessage: string) {
+import { toast } from "./toast";
+
+export function handleError(
+  error: unknown,
+  logMessage: string,
+  alertMessage: string
+) {
   console.error(logMessage, error);
-  alert(alertMessage);
+  toast(alertMessage);
 }

--- a/src/utils/toast.ts
+++ b/src/utils/toast.ts
@@ -1,0 +1,38 @@
+let container: HTMLDivElement | null = null;
+
+export function toast(message: string) {
+  if (typeof document === "undefined") return;
+  if (!container) {
+    container = document.createElement("div");
+    container.style.position = "fixed";
+    container.style.top = "1rem";
+    container.style.right = "1rem";
+    container.style.zIndex = "9999";
+    container.style.display = "flex";
+    container.style.flexDirection = "column";
+    container.style.gap = "0.5rem";
+    document.body.appendChild(container);
+  }
+  const toastElem = document.createElement("div");
+  toastElem.textContent = message;
+  toastElem.style.background = "#333";
+  toastElem.style.color = "#fff";
+  toastElem.style.padding = "0.5rem 1rem";
+  toastElem.style.borderRadius = "4px";
+  toastElem.style.boxShadow = "0 2px 6px rgba(0,0,0,0.2)";
+  toastElem.style.opacity = "1";
+  toastElem.style.transition = "opacity 0.5s ease";
+  container.appendChild(toastElem);
+  setTimeout(() => {
+    toastElem.style.opacity = "0";
+  }, 2500);
+  setTimeout(() => {
+    toastElem.remove();
+    if (container && container.childElementCount === 0) {
+      container.remove();
+      container = null;
+    }
+  }, 3000);
+}
+
+export default toast;


### PR DESCRIPTION
## Summary
- remove console.log statements from DashboardResultados and InformeTabs
- add simple toast utility and replace browser alerts across services and hooks

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 154 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68a80a88a0e48331b2c156f5def2fe1b