### PR TITLE
Count forms in report payload using real result fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ Run ESLint on the project files with:
 npm run lint
 ```
 
+## Testing
+
+This project includes a small test suite using Node's built-in test runner. To
+execute it, first compile the TypeScript sources and then run the tests:
+
+```bash
+npx tsc -p tsconfig.json --outDir dist_test
+node --test dist_test/utils/buildReportPayload.test.js
+```
+
 ## Project structure
 
 - `src/` - Application source code

--- a/src/utils/buildReportPayload.test.ts
+++ b/src/utils/buildReportPayload.test.ts
@@ -1,0 +1,45 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildReportPayload } from './buildReportPayload.js';
+import type { FlatResult } from './gatherResults';
+import type { EmpresaInfo } from '../types/report';
+
+test('counts rows with actual results for each form', () => {
+  const empresa: EmpresaInfo = { id: '1', nombre: 'Empresa', nit: '', logoUrl: '' };
+  const flat: FlatResult[] = [
+    {
+      Empresa: 'Empresa',
+      Sexo: 'F',
+      'PUNTAJE TOTAL del cuestionario de factores de riesgo psicosocial intralaboral - Forma A (puntaje transformado)': 10,
+    },
+    {
+      Empresa: 'Empresa',
+      Sexo: 'M',
+      'PUNTAJE TOTAL del cuestionario de factores de riesgo psicosocial intralaboral - Forma B (puntaje transformado)': 15,
+    },
+    {
+      Empresa: 'Empresa',
+      Sexo: 'M',
+      'PUNTAJE TOTAL del cuestionario de factores de riesgo psicosocial extralaboral (puntaje transformado)': 20,
+    },
+    {
+      Empresa: 'Empresa',
+      Sexo: 'F',
+      'PUNTAJE TOTAL del cuestionario de factores de riesgo psicosocial intralaboral - Forma A (puntaje transformado)': '',
+    },
+  ];
+
+  const payload = buildReportPayload({
+    empresa,
+    flat,
+    resumenA: undefined,
+    resumenB: undefined,
+    resumenExtra: undefined,
+    estresGlobal: null,
+  });
+
+  assert.equal(payload.muestra.total, 4);
+  assert.equal(payload.muestra.formaA, 1);
+  assert.equal(payload.muestra.formaB, 1);
+  assert.equal(payload.muestra.extralaboral, 1);
+});

--- a/src/utils/buildReportPayload.ts
+++ b/src/utils/buildReportPayload.ts
@@ -1,6 +1,14 @@
 import { ReportPayload, EmpresaInfo, Sociodemo } from "@/types/report";
 import { FlatResult } from "@/utils/gatherResults";
 
+// Field names used to detect the presence of results for each questionnaire.
+const TOTAL_FORMA_A =
+  "PUNTAJE TOTAL del cuestionario de factores de riesgo psicosocial intralaboral - Forma A (puntaje transformado)" as keyof FlatResult;
+const TOTAL_FORMA_B =
+  "PUNTAJE TOTAL del cuestionario de factores de riesgo psicosocial intralaboral - Forma B (puntaje transformado)" as keyof FlatResult;
+const TOTAL_EXTRALABORAL =
+  "PUNTAJE TOTAL del cuestionario de factores de riesgo psicosocial extralaboral (puntaje transformado)" as keyof FlatResult;
+
 function distribucion<T extends keyof FlatResult>(
   data: FlatResult[],
   key: T
@@ -36,6 +44,12 @@ function mapIndicadores(
   return out;
 }
 
+/**
+ * Construye la estructura de datos consumida por los reportes.
+ * La cantidad de respuestas por formulario se calcula verificando la
+ * presencia de los campos totales de cada cuestionario dentro de cada fila
+ * plana.
+ */
 export function buildReportPayload(params: {
   empresa: EmpresaInfo;
   flat: FlatResult[];
@@ -76,10 +90,11 @@ export function buildReportPayload(params: {
     fechaInformeISO: new Date().toISOString(),
     muestra: {
       total: flat.length,
-      // TODO: si FlatResult trae banderas por formulario, reemplazar los true por las condiciones reales
-      formaA: flat.filter(() => true).length,
-      formaB: flat.filter(() => true).length,
-      extralaboral: flat.filter(() => true).length,
+      formaA: flat.filter((r) => r[TOTAL_FORMA_A] !== undefined && r[TOTAL_FORMA_A] !== "").length,
+      formaB: flat.filter((r) => r[TOTAL_FORMA_B] !== undefined && r[TOTAL_FORMA_B] !== "").length,
+      extralaboral: flat.filter(
+        (r) => r[TOTAL_EXTRALABORAL] !== undefined && r[TOTAL_EXTRALABORAL] !== ""
+      ).length,
     },
     global: {
       formaA:


### PR DESCRIPTION
## Summary
- derive form counts by checking presence of total score fields in `buildReportPayload`
- document new report payload behavior and testing steps
- add node-based test covering form counting logic

## Testing
- `npm run lint` *(fails: nivelesRiesgo assigned but unused, etc.)*
- `npx tsc -p tsconfig.json --outDir dist_test`
- `node --test dist_test/utils/buildReportPayload.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a80a7618588331bc0263e3c0367157