### PR TITLE
Fix double requestAnimationFrame for PDF export

### DIFF
--- a/src/hooks/usePdfExport.ts
+++ b/src/hooks/usePdfExport.ts
@@ -14,7 +14,7 @@ export function usePdfExport() {
     // ciclo de pintado y confirmar que el DOM se actualizó tras los
     // cambios de estado.
     await new Promise<void>((resolve) =>
-      requestAnimationFrame(() => requestAnimationFrame(resolve))
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
     );
     try {
       if (ref.current) {


### PR DESCRIPTION
## Summary
- ensure resolve is called without timestamp when waiting a paint cycle

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`
- `npm run lint` (fails: 124 errors, 34 warnings)

------
https://chatgpt.com/codex/tasks/task_e_68a80ceeb5488331aa7728cda273df18