### PR TITLE
feat: add print-friendly PDF export utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "recharts": "^2.15.3",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
-    "xlsx": "^0.18.5"
+    "xlsx": "^0.18.5",
+    "html2pdf.js": "^0.10.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/src/components/AccordionItem.tsx
+++ b/src/components/AccordionItem.tsx
@@ -16,15 +16,15 @@ export default function AccordionItem({
   isOpen,
   onToggle,
 }: AccordionItemProps) {
-  const contentId = `${id}-content`;
+  const panelId = `panel-${id}`;
 
   return (
-    <div className="rounded-2xl border border-slate-200 shadow-sm bg-white">
+    <div className="rounded-2xl border border-slate-200 shadow-sm bg-white avoid-break">
       <button
         id={id}
         type="button"
         aria-expanded={isOpen}
-        aria-controls={contentId}
+        aria-controls={panelId}
         onClick={onToggle}
         className="w-full flex items-center justify-between px-4 py-3 text-left font-semibold text-[#313B4A]"
       >
@@ -35,10 +35,11 @@ export default function AccordionItem({
         />
       </button>
       <div
-        id={contentId}
+        id={panelId}
         role="region"
         aria-labelledby={id}
-        className={isOpen ? "block" : "hidden"}
+        className="overflow-hidden transition-[height] duration-300 ease-in-out print:!block avoid-break"
+        style={{ height: isOpen ? 'auto' : 0 }}
       >
         <div className="px-4 pb-4">{children}</div>
       </div>

--- a/src/components/ExportButtons.tsx
+++ b/src/components/ExportButtons.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { exportWithHtml2Pdf, printNative } from '@/utils/exportPdf';
+
+export default function ExportButtons({ rootId = 'informe-root' }: { rootId?: string }) {
+  const getRoot = () => document.getElementById(rootId)!;
+
+  return (
+    <div className="flex gap-2 print:hidden">
+      <button
+        className="rounded-lg bg-sky-600 px-3 py-2 text-white hover:bg-sky-700"
+        onClick={() => printNative(getRoot())}
+      >
+        Imprimir / Guardar PDF
+      </button>
+      <button
+        className="rounded-lg bg-slate-700 px-3 py-2 text-white hover:bg-slate-800"
+        onClick={() => exportWithHtml2Pdf(getRoot(), 'informe.pdf')}
+      >
+        Exportar PDF (html2pdf)
+      </button>
+    </div>
+  );
+}

--- a/src/components/ReportePDF.tsx
+++ b/src/components/ReportePDF.tsx
@@ -71,10 +71,14 @@ const ReportePDF = forwardRef<HTMLDivElement, Props>(
     );
 
     return (
-      <div ref={ref} className="w-[794pt] bg-white text-black text-sm leading-6">
+      <div
+        ref={ref}
+        id="informe-root"
+        className="w-[794pt] bg-white text-black text-sm leading-6 avoid-break"
+      >
         {sections.portada && (
           <>
-            <section className="min-h-[1123pt] p-16 flex flex-col justify-between">
+            <section className="min-h-[1123pt] p-16 flex flex-col justify-between avoid-break">
               <div>
                 <h1 className="text-3xl font-bold" style={{ color: theme.primary }}>
                   {options?.tituloPortada || "Informe de Evaluación de Riesgo Psicosocial"}
@@ -95,7 +99,7 @@ const ReportePDF = forwardRef<HTMLDivElement, Props>(
 
         {sections.resumenGlobal && (
           <>
-            <section className="p-10">
+            <section className="p-10 avoid-break">
               <Title>Resumen Global</Title>
               <div className="mt-4 grid grid-cols-2 gap-4">
                 {global.formaA && (
@@ -138,7 +142,7 @@ const ReportePDF = forwardRef<HTMLDivElement, Props>(
 
         {sections.intralaboral && (
           <>
-            <section className="p-10">
+            <section className="p-10 avoid-break">
               <Title>Resultados Intralaborales</Title>
               <div className="mt-6 space-y-6">
                 {graficos.formaA}
@@ -152,7 +156,7 @@ const ReportePDF = forwardRef<HTMLDivElement, Props>(
 
         {sections.extralaboral && (
           <>
-            <section className="p-10">
+            <section className="p-10 avoid-break">
               <Title>Resultados Extralaborales</Title>
               <div className="mt-6 space-y-6">
                 {graficos.extralaboral}
@@ -165,7 +169,7 @@ const ReportePDF = forwardRef<HTMLDivElement, Props>(
 
         {sections.sociodemografia && (
           <>
-            <section className="p-10">
+            <section className="p-10 avoid-break">
               <Title>Sociodemografía de la Muestra</Title>
               {narrativaSociodemo && <p className="mt-4 text-justify">{narrativaSociodemo}</p>}
               {recomendacionesSociodemo && <p className="mt-4 text-justify">{recomendacionesSociodemo}</p>}
@@ -177,7 +181,7 @@ const ReportePDF = forwardRef<HTMLDivElement, Props>(
 
         {sections.metodologia && (
           <>
-            <section className="p-10">
+            <section className="p-10 avoid-break">
               <Title>Metodología</Title>
               <div className="mt-3">
                 <Metodologia />
@@ -189,7 +193,7 @@ const ReportePDF = forwardRef<HTMLDivElement, Props>(
 
         {sections.normativa && (
           <>
-            <section className="p-10">
+            <section className="p-10 avoid-break">
               <Title>Normativa</Title>
               <p className="mt-3">{strings.normativa}</p>
             </section>
@@ -199,7 +203,7 @@ const ReportePDF = forwardRef<HTMLDivElement, Props>(
 
         {sections.recomendaciones && (
           <>
-            <section className="p-10">
+            <section className="p-10 avoid-break">
               <Title>Recomendaciones</Title>
               <ul className="mt-4 list-disc pl-6 space-y-1">
                 {recomendaciones.map((r, i) => (
@@ -212,7 +216,7 @@ const ReportePDF = forwardRef<HTMLDivElement, Props>(
         )}
 
         {sections.conclusiones && (
-          <section className="p-10">
+          <section className="p-10 avoid-break">
             <Title>Conclusiones</Title>
             <p className="mt-3">{conclusiones}</p>
           </section>

--- a/src/components/TablaInformativa.tsx
+++ b/src/components/TablaInformativa.tsx
@@ -10,11 +10,11 @@ interface TablaInformativaProps {
 }
 
 export default function TablaInformativa({ headers, rows, exportMode = false }: TablaInformativaProps) {
-  const containerClasses = `rounded-2xl bg-white ${exportMode ? "shadow-none" : "shadow-sm"} p-4 md:p-6 font-montserrat text-text-main`;
+  const containerClasses = `rounded-2xl bg-white ${exportMode ? "shadow-none" : "shadow-sm"} p-4 md:p-6 font-montserrat text-text-main avoid-break`;
 
   return (
     <div className={containerClasses}>
-      <table className="w-full text-left border-collapse">
+      <table className="w-full text-left border-collapse avoid-break">
         <thead className="bg-gradient-to-r from-primary-gradient-from to-primary-gradient-to text-white font-semibold">
           <tr>
             <th scope="col" className="py-2 px-3">{headers[0]}</th>
@@ -25,7 +25,7 @@ export default function TablaInformativa({ headers, rows, exportMode = false }: 
           {rows.map((row) => (
             <tr
               key={row.dimension}
-              className={`block md:table-row border-b border-slate-100 odd:bg-primary-light even:bg-white text-text-main ${!exportMode ? "hover:bg-primary-light" : ""}`}
+              className={`block md:table-row border-b border-slate-100 odd:bg-primary-light even:bg-white text-text-main ${!exportMode ? "hover:bg-primary-light" : ""} avoid-break`}
             >
               <th
                 scope="row"

--- a/src/components/TablaSociodemo.tsx
+++ b/src/components/TablaSociodemo.tsx
@@ -39,7 +39,7 @@ export default function TablaSociodemo({ payload, exportMode = false }: Props) {
   }
 
   return (
-    <div className="rounded-2xl shadow-sm bg-white p-4 md:p-6 font-montserrat text-[#172349]">
+    <div className="rounded-2xl shadow-sm bg-white p-4 md:p-6 font-montserrat text-[#172349] avoid-break">
       <div className="mb-4">
         <h3 className="text-lg font-semibold">Ficha sociodemográfica</h3>
         <p className="text-sm text-gray-500">N = {total}</p>
@@ -53,7 +53,7 @@ export default function TablaSociodemo({ payload, exportMode = false }: Props) {
               <div className="inline-block bg-blue-50 text-blue-700 text-xs font-semibold uppercase rounded-xl px-3 py-1 mb-2">
                 {titulo}
               </div>
-              <table className="w-full text-sm">
+              <table className="w-full text-sm avoid-break">
                 <thead className="hidden lg:table-header-group text-gray-500">
                   <tr className="border-b">
                     <th className="text-left py-2">Detalle</th>
@@ -67,7 +67,7 @@ export default function TablaSociodemo({ payload, exportMode = false }: Props) {
                     const porcentaje = formatter.format(percent);
                     const rowClass = `border-b ${!exportMode ? "hover:bg-slate-50" : ""}`;
                     return (
-                      <tr key={label} className={rowClass}>
+                      <tr key={label} className={`${rowClass} avoid-break`}>
                         <td className="py-2">{label}</td>
                         <td className="py-2 text-right align-top">
                           <span className="hidden lg:inline">{total > 0 ? count : "—"}</span>

--- a/src/index.css
+++ b/src/index.css
@@ -111,6 +111,28 @@
 }
 
 
-@page { size: A4; margin: 24pt; }
+/* Tamaño y márgenes del PDF */
+@page { size: A4; margin: 12mm; }
+
+/* Modo impresión */
+@media print {
+  html, body { height: auto !important; }
+
+  /* Quitar sombras/bordes ruidosos y sticky/fixed */
+  .shadow, .shadow-sm, .shadow-md { box-shadow: none !important; }
+  [class*="sticky"], [style*="position: sticky"] { position: static !important; top: auto !important; }
+  [class*="fixed"] { position: static !important; }
+
+  /* Abrir paneles de acordeón y evitar recortes */
+  [id^="panel-"] { height: auto !important; overflow: visible !important; }
+
+  /* Reglas anti-corte */
+  .avoid-break { break-inside: avoid-page; page-break-inside: avoid; }
+  table { break-inside: auto; }
+  tr, th, td { break-inside: avoid; page-break-inside: avoid; }
+
+  /* Reset visual para PDF limpio */
+  .print-reset { box-shadow: none !important; border-color: #e5e7eb !important; }
+}
+
 .page-break { page-break-before: always; }
-h1, h2, h3, ul, li, table { page-break-inside: avoid; }

--- a/src/types/html2pdf.d.ts
+++ b/src/types/html2pdf.d.ts
@@ -1,0 +1,1 @@
+declare module 'html2pdf.js';

--- a/src/utils/exportPdf.ts
+++ b/src/utils/exportPdf.ts
@@ -1,0 +1,66 @@
+export function prepareForExport(root: HTMLElement) {
+  // Abrir paneles de acordeón y quitar restricciones
+  root.querySelectorAll<HTMLElement>('[id^="panel-"]').forEach(p => {
+    p.style.height = 'auto';
+    p.style.overflow = 'visible';
+  });
+  // Desactivar animaciones/transiciones que “congelan” alturas
+  root.querySelectorAll<HTMLElement>('*').forEach(el => {
+    el.style.transition = 'none';
+    el.style.animation = 'none';
+  });
+  // Forzar reflow
+  void root.offsetHeight;
+}
+
+export async function waitForAssets(root: HTMLElement) {
+  // Esperar fuentes e imágenes
+  try {
+    await (document as unknown as { fonts?: { ready: Promise<void> } }).fonts?.ready;
+  } catch {
+    /* ignore */
+  }
+  const imgs = Array.from(root.querySelectorAll('img'));
+  await Promise.all(
+    imgs.map(
+      (img) =>
+        img.complete
+          ? Promise.resolve()
+          : new Promise<void>((res) => {
+              img.onload = img.onerror = () => res();
+            }),
+    ),
+  );
+}
+
+/* Opción A: impresión nativa */
+export async function printNative(root: HTMLElement) {
+  prepareForExport(root);
+  await waitForAssets(root);
+  window.print();
+}
+
+/* Opción B: html2pdf.js */
+export async function exportWithHtml2Pdf(root: HTMLElement, filename = 'informe.pdf') {
+  prepareForExport(root);
+  await waitForAssets(root);
+
+  const { default: html2pdf } = await import('html2pdf.js');
+  const opt = {
+    margin:       [10, 10, 10, 10],             // mm
+    filename,
+    image:        { type: 'jpeg', quality: 0.98 },
+    html2canvas:  {
+      scale: 2,                                  // nitidez
+      useCORS: true,
+      letterRendering: true,
+      scrollY: 0,
+      windowWidth: document.documentElement.scrollWidth
+    },
+    jsPDF:        { unit: 'mm', format: 'a4', orientation: 'portrait' },
+    pagebreak:    { mode: ['css', 'legacy'], avoid: '.avoid-break, table, tr' }
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (html2pdf() as any).from(root).set(opt).save();
+}


### PR DESCRIPTION
## Summary
- add html2pdf.js dependency and type stub
- introduce global print stylesheet and avoid-break helpers
- implement reusable PDF export utilities and buttons
- update accordion and tables for print-safe layout

## Testing
- `npm run lint` *(fails: 153 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68a81122d2f88331afcfc844a71f25de