### PR TITLE
feat: add superuser role and restrict informe access

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,7 +29,7 @@ import useCredenciales from "./hooks/useCredenciales";
 import useSurveySteps from "./hooks/useSurveySteps";
 import { db } from "./firebaseConfig";
 
-type RolUsuario = "ninguno" | "psicologa" | "dueno";
+type RolUsuario = "ninguno" | "psicologa" | "dueno" | "superusuario";
 
 export default function App() {
   const {
@@ -153,7 +153,7 @@ export default function App() {
       case "dashboard":
         return (
           <DashboardResultados
-            rol={rol as "psicologa" | "dueno"}
+            rol={rol as "psicologa" | "dueno" | "superusuario"}
             empresaNombre={empresaActual || undefined}
             empresaFiltro={
               rol === "dueno" ? empresaActual || undefined : undefined

--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -43,7 +43,7 @@ const nivelesRiesgo = [
 ];
 
 type Props = {
-  rol: "psicologa" | "dueno";
+  rol: "psicologa" | "dueno" | "superusuario";
   empresaNombre?: string;
   soloGenerales?: boolean;
   empresaFiltro?: string;
@@ -344,8 +344,18 @@ export default function DashboardResultados({
   const containerRef = useRef<HTMLDivElement>(null);
   const { ref: offscreenRef, rendering, progress, exportNow } = usePdfExport();
 
-  const saludo = rol === "psicologa" ? "Hola Lilian Navas" : empresaNombre || "";
-  const cargo = rol === "psicologa" ? "Psicologist" : "Empresa";
+  const saludo =
+    rol === "psicologa"
+      ? "Hola Lilian Navas"
+      : rol === "superusuario"
+      ? "Hola Superusuario"
+      : empresaNombre || "";
+  const cargo =
+    rol === "psicologa"
+      ? "Psicologist"
+      : rol === "superusuario"
+      ? "Superusuario"
+      : "Empresa";
 
   const tabPill =
     "px-5 py-2 rounded-full font-semibold border border-[#B2E2FF] text-[#172349] shrink-0 data-[state=active]:text-white data-[state=active]:bg-gradient-to-r data-[state=active]:from-[#38BDF8] data-[state=active]:to-[#265FF2]";
@@ -2794,7 +2804,7 @@ export default function DashboardResultados({
         {!soloGenerales && (
           <TabsTrigger className={tabPill} value="empresas">Empresas</TabsTrigger>
         )}
-        {rol === "psicologa" && (
+        {rol === "superusuario" && (
           <TabsTrigger className={tabPill} value="informeCompleto">
             Informe completo
           </TabsTrigger>
@@ -2803,7 +2813,7 @@ export default function DashboardResultados({
 
       <TabsList className="mb-6 py-2 px-4 w-full flex gap-2 overflow-x-auto whitespace-nowrap">
         <TabsTrigger className={tabPill} value="general">General</TabsTrigger>
-        {rol === "psicologa" && (
+        {rol === "superusuario" && (
           <TabsTrigger className={tabPill} value="informe">
             Informe
           </TabsTrigger>
@@ -2834,7 +2844,7 @@ export default function DashboardResultados({
         </TabsContent>
 
         {/* ---- INFORME COMPLETO ---- */}
-        {rol === "psicologa" && (
+        {rol === "superusuario" && (
           <TabsContent value="informeCompleto">
             {datosInforme.length === 0 ? (
               <div className="text-[var(--gray-medium)] py-4">
@@ -2870,7 +2880,7 @@ export default function DashboardResultados({
           </TabsContent>
         )}
         {/* ---- INFORME ---- */}
-        {rol === "psicologa" && (
+        {rol === "superusuario" && (
           <TabsContent value="informe">
             <div className="max-w-4xl mx-auto">
               <section className="bg-white rounded-xl shadow p-6 space-y-6">

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -5,7 +5,10 @@ type Usuario = { usuario: string; password: string; rol: string; empresa?: strin
 
 type Props = {
   usuarios: Usuario[];
-  onLogin: (rol: "psicologa" | "dueno", empresa?: string) => void;
+  onLogin: (
+    rol: "psicologa" | "dueno" | "superusuario",
+    empresa?: string
+  ) => void;
   onCancel?: () => void;
 };
 
@@ -21,7 +24,10 @@ export default function Login({ usuarios, onLogin, onCancel }: Props) {
       (u) => u.usuario === usuario.toLowerCase() && u.password === password
     );
     if (user) {
-      onLogin(user.rol as "psicologa" | "dueno", user.empresa);
+      onLogin(
+        user.rol as "psicologa" | "dueno" | "superusuario",
+        user.empresa
+      );
     } else {
       setError("Usuario o clave incorrectos.");
     }

--- a/src/components/dashboard/ExportActions.tsx
+++ b/src/components/dashboard/ExportActions.tsx
@@ -3,7 +3,7 @@ import { FileDown, FileText, Home as HomeIcon } from "lucide-react";
 
 interface Props {
   onBack?: () => void;
-  rol: "psicologa" | "dueno";
+  rol: "psicologa" | "dueno" | "superusuario";
   tab: string;
   handleExportar: () => void;
   handleExportPDF: () => void;
@@ -26,7 +26,7 @@ const ExportActions: React.FC<Props> = ({
           <HomeIcon size={20} /> Volver al inicio
         </button>
       )}
-      {rol === "psicologa" &&
+      {rol === "superusuario" &&
         (tab === "informe" || tab === "informeCompleto") && (
           <div className="flex gap-2">
             <button

--- a/src/config/credentials.json
+++ b/src/config/credentials.json
@@ -1,4 +1,5 @@
 [
+  { "usuario": "superuser", "password": "superuser123", "rol": "superusuario" },
   { "usuario": "psicologa", "password": "cogent2024", "rol": "psicologa" },
   { "usuario": "sonria", "password": "sonria123", "rol": "dueno", "empresa": "Sonria" },
   { "usuario": "aeropuerto", "password": "eldorado123", "rol": "dueno", "empresa": "Aeropuerto El Dorado" }

--- a/src/data/demoCredenciales.ts
+++ b/src/data/demoCredenciales.ts
@@ -1,6 +1,7 @@
 import { CredencialEmpresa } from "@/types";
 
 export const demoCredencialesConst: (CredencialEmpresa & { rol: string })[] = [
+  { usuario: "superuser", password: "superuser123", rol: "superusuario" },
   { usuario: "psicologa", password: "cogent2024", rol: "psicologa" },
   { usuario: "sonria", password: "sonria123", rol: "dueno", empresa: "Sonria" },
   {


### PR DESCRIPTION
## Summary
- add `superusuario` role and corresponding credentials
- expose superuser in login/app state handling
- restrict Informe tabs and export actions exclusively to superuser

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68aa59bb4a7c8331b535ae37a7bb6539