### PR TITLE
Restore detailed dashboard survey tabs

### DIFF
--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -334,7 +334,7 @@ export default function DashboardResultados({
   } = useDashboardData(empresaFiltro);
 
   const [tab, setTab] = useState("general");
-  const [tabGeneral, setTabGeneral] = useState("resumen");
+  const [tabGeneral, setTabGeneral] = useState("formaA");
   const [categoriaFicha, setCategoriaFicha] = useState<string>(
     categoriasFicha[0].key
   );
@@ -2818,17 +2818,28 @@ export default function DashboardResultados({
             tabClass={tabPill}
             chartType={chartType}
             datosA={datosA}
-            datosB={datosB}
-            datosExtra={datosExtra}
-            datosEstres={datosEstres}
             resumenA={resumenA}
+            promediosDominiosA={promediosDominiosA}
+            promediosDimensionesA={promediosDimensionesA}
+            dominiosA={dominiosA}
+            dimensionesA={dimensionesA}
+            datosB={datosB}
             resumenB={resumenB}
+            promediosDominiosB={promediosDominiosB}
+            promediosDimensionesB={promediosDimensionesB}
+            dominiosB={dominiosB}
+            dimensionesB={dimensionesB}
+            datosExtra={datosExtra}
             resumenExtra={resumenExtra}
+            promediosDimensionesExtra={promediosDimensionesExtra}
+            dimensionesExtra={dimensionesExtra}
+            datosEstres={datosEstres}
             resumenEstres={resumenEstres}
             categoriaFicha={categoriaFicha}
             onCategoriaChange={(v) => setCategoriaFicha(v)}
             categoriasFicha={categoriasFicha}
             fichaConteos={fichaConteosGlobal}
+            soloGenerales={soloGenerales}
           />
 
         </TabsContent>

--- a/src/components/dashboard/GeneralResultsTabs.tsx
+++ b/src/components/dashboard/GeneralResultsTabs.tsx
@@ -1,8 +1,15 @@
-import React from "react";
+import React, { useState } from "react";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
-import GraficaBarraSimple from "@/components/GraficaBarraSimple";
 import FichaTecnicaTabs, { CategoriaFicha } from "./FichaTecnicaTabs";
-import { NivelResumen, ResultRow, CategoriaConteo, NivelResumenCantidad } from "@/types";
+import {
+  ResultRow,
+  CategoriaConteo,
+  NivelResumenCantidad,
+  PromedioDato,
+} from "@/types";
+import FormaTabs from "./FormaTabs";
+import ExtralaboralSection from "./ExtralaboralSection";
+import EstresSection from "./EstresSection";
 
 export default function GeneralResultsTabs({
   value,
@@ -10,77 +17,135 @@ export default function GeneralResultsTabs({
   tabClass,
   chartType,
   datosA,
-  datosB,
-  datosExtra,
-  datosEstres,
   resumenA,
+  promediosDominiosA,
+  promediosDimensionesA,
+  dominiosA,
+  dimensionesA,
+  datosB,
   resumenB,
+  promediosDominiosB,
+  promediosDimensionesB,
+  dominiosB,
+  dimensionesB,
+  datosExtra,
   resumenExtra,
+  promediosDimensionesExtra,
+  dimensionesExtra,
+  datosEstres,
   resumenEstres,
   categoriaFicha,
   onCategoriaChange,
   categoriasFicha,
   fichaConteos,
+  soloGenerales,
 }: {
   value: string;
   onChange: (v: string) => void;
   tabClass: string;
   chartType: "bar" | "histogram" | "pie";
   datosA: ResultRow[];
-  datosB: ResultRow[];
-  datosExtra: ResultRow[];
-  datosEstres: ResultRow[];
   resumenA: NivelResumenCantidad[];
+  promediosDominiosA: PromedioDato[];
+  promediosDimensionesA: PromedioDato[];
+  dominiosA: string[];
+  dimensionesA: string[];
+  datosB: ResultRow[];
   resumenB: NivelResumenCantidad[];
+  promediosDominiosB: PromedioDato[];
+  promediosDimensionesB: PromedioDato[];
+  dominiosB: string[];
+  dimensionesB: string[];
+  datosExtra: ResultRow[];
   resumenExtra: NivelResumenCantidad[];
+  promediosDimensionesExtra: PromedioDato[];
+  dimensionesExtra: string[];
+  datosEstres: ResultRow[];
   resumenEstres: NivelResumenCantidad[];
   categoriaFicha: string;
   onCategoriaChange: (v: string) => void;
   categoriasFicha: readonly CategoriaFicha[];
   fichaConteos: Record<string, CategoriaConteo[]>;
+  soloGenerales?: boolean;
 }) {
+  const [tabA, setTabA] = useState("global");
+  const [tabB, setTabB] = useState("global");
+
   return (
     <Tabs value={value} onValueChange={onChange} className="w-full">
       <TabsList className="mb-6 py-2 px-4 scroll-pl-4 w-full flex gap-2 overflow-x-auto whitespace-nowrap">
-        <TabsTrigger className={tabClass} value="resumen">
-          Resultados
+        <TabsTrigger className={tabClass} value="formaA">
+          Forma A (Intralaboral)
+        </TabsTrigger>
+        <TabsTrigger className={tabClass} value="formaB">
+          Forma B (Intralaboral)
+        </TabsTrigger>
+        <TabsTrigger className={tabClass} value="extralaboral">
+          Extralaboral
+        </TabsTrigger>
+        <TabsTrigger className={tabClass} value="estres">
+          Estrés
         </TabsTrigger>
         <TabsTrigger className={tabClass} value="ficha">
           Ficha técnica
         </TabsTrigger>
       </TabsList>
-      <TabsContent value="resumen">
-        <div className="grid md:grid-cols-2 gap-4">
-          {datosA.length > 0 && (
-            <GraficaBarraSimple
-              resumen={resumenA}
-              titulo="Niveles de Forma A"
-              chartType={chartType}
-            />
-          )}
-          {datosB.length > 0 && (
-            <GraficaBarraSimple
-              resumen={resumenB}
-              titulo="Niveles de Forma B"
-              chartType={chartType}
-            />
-          )}
-          {datosExtra.length > 0 && (
-            <GraficaBarraSimple
-              resumen={resumenExtra}
-              titulo="Niveles Extralaborales"
-              chartType={chartType}
-            />
-          )}
-          {datosEstres.length > 0 && (
-            <GraficaBarraSimple
-              resumen={resumenEstres}
-              titulo="Niveles de Estrés"
-              chartType={chartType}
-            />
-          )}
-        </div>
+
+      <TabsContent value="formaA">
+        <FormaTabs
+          value={tabA}
+          onChange={setTabA}
+          datos={datosA}
+          resumen={resumenA}
+          promediosDominios={promediosDominiosA}
+          promediosDimensiones={promediosDimensionesA}
+          dominios={dominiosA}
+          dimensiones={dimensionesA}
+          chartType={chartType}
+          tabClass={tabClass}
+          soloGenerales={soloGenerales}
+          tipo="formaA"
+          keyResultado="resultadoFormaA"
+        />
       </TabsContent>
+
+      <TabsContent value="formaB">
+        <FormaTabs
+          value={tabB}
+          onChange={setTabB}
+          datos={datosB}
+          resumen={resumenB}
+          promediosDominios={promediosDominiosB}
+          promediosDimensiones={promediosDimensionesB}
+          dominios={dominiosB}
+          dimensiones={dimensionesB}
+          chartType={chartType}
+          tabClass={tabClass}
+          soloGenerales={soloGenerales}
+          tipo="formaB"
+          keyResultado="resultadoFormaB"
+        />
+      </TabsContent>
+
+      <TabsContent value="extralaboral">
+        <ExtralaboralSection
+          datosExtra={datosExtra}
+          resumenExtra={resumenExtra}
+          promediosDimensionesExtra={promediosDimensionesExtra}
+          chartType={chartType}
+          soloGenerales={soloGenerales}
+        />
+      </TabsContent>
+
+      <TabsContent value="estres">
+        <EstresSection
+          datosEstres={datosEstres}
+          resumenEstres={resumenEstres}
+          chartType={chartType}
+          soloGenerales={soloGenerales}
+        />
+      </TabsContent>
+
       <TabsContent value="ficha">
         <FichaTecnicaTabs
           categorias={categoriasFicha}
@@ -94,3 +159,4 @@ export default function GeneralResultsTabs({
     </Tabs>
   );
 }
+


### PR DESCRIPTION
## Summary
- Restore dashboard tabs for Forma A, Forma B, Extralaboral, and Estrés with original ordering
- Reintroduce Extralaboral and Estrés sections to feed data into their tabs
- Update dashboard state management to default to Forma A and pass detailed result data

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js'; `npm install` blocked with 403)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5ab3ce408331a5ce1b19a50329a9