### PR TITLE
Rename Informe completo tab to Individual

### DIFF
--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -2806,7 +2806,7 @@ export default function DashboardResultados({
         )}
         {rol === "superusuario" && (
           <TabsTrigger className={tabPill} value="informeCompleto">
-            Informe completo
+            Individual
           </TabsTrigger>
         )}
       </TabsList>
@@ -2854,7 +2854,7 @@ export default function DashboardResultados({
 
         </TabsContent>
 
-        {/* ---- INFORME COMPLETO ---- */}
+        {/* ---- INDIVIDUAL ---- */}
         {rol === "superusuario" && (
           <TabsContent value="informeCompleto">
             {datosInforme.length === 0 ? (


### PR DESCRIPTION
## Summary
- rename "Informe completo" tab label to "Individual" in DashboardResultados

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68abb3d00898833187f3abf414d20ed4