### PR TITLE
Rename Individual results tab to Excel

### DIFF
--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -2806,7 +2806,7 @@ export default function DashboardResultados({
         )}
         {(rol === "superusuario" || rol === "psicologa") && (
           <TabsTrigger className={tabPill} value="informeCompleto">
-            Individual
+            Excel
           </TabsTrigger>
         )}
       </TabsList>


### PR DESCRIPTION
## Summary
- rename the DashboardResults "Individual" tab to "Excel"

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')
- `npm run build` (fails: Cannot find type definition files)


------
https://chatgpt.com/codex/tasks/task_e_68bcbfed5e2c83319b2b41db6615b05d