### PR TITLE
remove unused cloud functions config

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -5,23 +5,6 @@
     "rules": "firestore.rules",
     "indexes": "firestore.indexes.json"
   },
-  "functions": [
-    {
-      "source": "functions",
-      "codebase": "default",
-      "ignore": [
-        "node_modules",
-        ".git",
-        "firebase-debug.log",
-        "firebase-debug.*.log",
-        "*.local"
-      ],
-      "predeploy": [
-        "npm --prefix \"$RESOURCE_DIR\" run lint",
-        "npm --prefix \"$RESOURCE_DIR\" run build"
-      ]
-    }
-  ],
   "hosting": {
     "public": "frontend/dist",
     "ignore": [


### PR DESCRIPTION
## Summary
- remove functions config from firebase.json to prevent Firebase from expecting functions directory

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')
- `npm ci` (fails: 403 Forbidden - GET https://registry.npmjs.org/html2pdf.js)


------
https://chatgpt.com/codex/tasks/task_e_68bcd04613808331a4eee8914941e2ee