### PR TITLE
fix firebase hosting path

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -6,7 +6,7 @@
     "indexes": "firestore.indexes.json"
   },
   "hosting": {
-    "public": "frontend/dist",
+    "public": "dist",
     "ignore": [
       "firebase.json",
       "**/.*",


### PR DESCRIPTION
## Summary
- point Firebase hosting to the correct build output directory (`dist`)

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js' - dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bcd3a071688331854283edd126684a