### PR TITLE
Disable automatic translations and input autocorrect

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,15 +1,16 @@
 <!doctype html>
-<html lang="en">
+<html lang="es" translate="no">
   <head>
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=Poppins:wght@400&family=Roboto:wght@400&display=swap" rel="stylesheet">
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/logo_forma.png" />
     <link rel="apple-touch-icon" href="/logo_forma.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="google" content="notranslate" />
     <title>COGENT - Evaluación Psicosocial</title>
   </head>
-  <body>
-    <div id="root"></div>
+  <body translate="no">
+    <div id="root" translate="no"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/components/FichaDatosGenerales.tsx
+++ b/src/components/FichaDatosGenerales.tsx
@@ -36,6 +36,14 @@ const tipoSalario = [
   "Todo variable (a destajo/por producción/por comisión)"
 ];
 
+const inputNoAutoCorrectProps = {
+  autoComplete: "off",
+  autoCorrect: "off",
+  autoCapitalize: "none",
+  spellCheck: false,
+  translate: "no" as const,
+};
+
 export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Props) {
   const empresas = empresasIniciales;
   const [empresa, setEmpresa] = useState("");
@@ -148,9 +156,8 @@ export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Pr
       </div>
 
       <form
-
+        translate="no"
         className="bg-white rounded-3xl shadow-xl p-8 md:p-12 w-full max-w-2xl mx-auto animate-fadeIn flex flex-col gap-4"
-
         onSubmit={handleSubmit}
       >
         <h2 className="text-2xl md:text-3xl font-bold text-[#132045] text-center mb-2 font-montserrat">
@@ -183,6 +190,7 @@ export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Pr
         <input
           type="date"
           name="fecha"
+          {...inputNoAutoCorrectProps}
           className={cn(
             "input mb-2 w-full border border-gray-300 bg-white rounded-xl px-4 py-2",
             erroresCampos["fecha"] && "border-red-500"
@@ -196,6 +204,7 @@ export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Pr
         <input
           type="text"
           name="nombre"
+          {...inputNoAutoCorrectProps}
           placeholder="Nombre completo*"
           className={cn(
             "input w-full md:flex-1 border border-gray-300 bg-white rounded-xl px-4 py-2",
@@ -207,6 +216,7 @@ export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Pr
         <input
           type="text"
           name="cedula"
+          {...inputNoAutoCorrectProps}
           placeholder="Cédula/Documento*"
           className={cn(
             "input w-full md:flex-1 border border-gray-300 bg-white rounded-xl px-4 py-2",
@@ -234,6 +244,7 @@ export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Pr
         <input
           type="number"
           name="nacimiento"
+          {...inputNoAutoCorrectProps}
           placeholder="Año de nacimiento*"
           className={cn(
             "input w-full md:flex-1 border border-gray-300 bg-white rounded-xl px-4 py-2",
@@ -280,6 +291,7 @@ export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Pr
       <input
         type="text"
         name="ocupacion"
+        {...inputNoAutoCorrectProps}
         placeholder="Ocupación o profesión*"
         className={cn(
           "input w-full border border-gray-300 bg-white rounded-xl px-4 py-2",
@@ -293,6 +305,7 @@ export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Pr
         <input
           type="text"
           name="residenciaCiudad"
+          {...inputNoAutoCorrectProps}
           placeholder="Ciudad/Municipio residencia*"
           className={cn(
             "input w-full md:flex-1 border border-gray-300 bg-white rounded-xl px-4 py-2",
@@ -304,6 +317,7 @@ export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Pr
         <input
           type="text"
           name="residenciaDepto"
+          {...inputNoAutoCorrectProps}
           placeholder="Departamento residencia*"
           className={cn(
             "input w-full md:flex-1 border border-gray-300 bg-white rounded-xl px-4 py-2",
@@ -348,6 +362,7 @@ export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Pr
       <input
         type="number"
         name="dependientes"
+        {...inputNoAutoCorrectProps}
         placeholder="Nº de personas que dependen de usted*"
         className="input w-full border border-gray-300 bg-white rounded-xl px-4 py-2"
         value={datos.dependientes}
@@ -360,6 +375,7 @@ export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Pr
         <input
           type="text"
           name="trabajoCiudad"
+          {...inputNoAutoCorrectProps}
           placeholder="Ciudad/Municipio trabajo*"
           className={cn(
             "input w-full md:flex-1 border border-gray-300 bg-white rounded-xl px-4 py-2",
@@ -371,6 +387,7 @@ export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Pr
         <input
           type="text"
           name="trabajoDepto"
+          {...inputNoAutoCorrectProps}
           placeholder="Departamento trabajo*"
           className={cn(
             "input w-full md:flex-1 border border-gray-300 bg-white rounded-xl px-4 py-2",
@@ -395,6 +412,7 @@ export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Pr
           <input
             type="number"
             name="aniosEmpresa"
+            {...inputNoAutoCorrectProps}
             placeholder="¿Cuántos años en la empresa?*"
             className={cn(
               "input w-full md:flex-1 border border-gray-300 bg-white rounded-xl px-4 py-2",
@@ -412,6 +430,7 @@ export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Pr
         <input
           type="text"
           name="cargo"
+          {...inputNoAutoCorrectProps}
           placeholder="Nombre del cargo*"
           className={cn(
             "input w-full md:flex-1 border border-gray-300 bg-white rounded-xl px-4 py-2",
@@ -450,6 +469,7 @@ export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Pr
           <input
             type="number"
             name="aniosCargo"
+            {...inputNoAutoCorrectProps}
             placeholder="¿Cuántos años en el cargo?*"
             className={cn(
               "input w-full md:flex-1 border border-gray-300 bg-white rounded-xl px-4 py-2",
@@ -466,6 +486,7 @@ export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Pr
       <input
         type="text"
         name="area"
+        {...inputNoAutoCorrectProps}
         placeholder="Nombre del área/departamento/sección*"
         className={cn(
           "input w-full border border-gray-300 bg-white rounded-xl px-4 py-2",
@@ -493,6 +514,7 @@ export default function FichaDatosGenerales({ empresasIniciales, onGuardar }: Pr
         <input
           type="number"
           name="horasDiarias"
+          {...inputNoAutoCorrectProps}
           placeholder="Horas diarias establecidas*"
           className={cn(
             "input w-full md:flex-1 border border-gray-300 bg-white rounded-xl px-4 py-2",


### PR DESCRIPTION
## Summary
- set the document language to Spanish and mark the shell/root elements and Google metadata to discourage automatic translation
- add shared input props to disable translation, autocorrect, autocapitalize, spellcheck, and autocomplete on sensitive fields in the general data form

## Testing
- npm run lint *(fails: missing dev dependency @eslint/js in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939b9611e7883209978fca1cf1916db)