### PR TITLE
Fix empresa admin edit and delete

### DIFF
--- a/src/components/AdminEmpresas.tsx
+++ b/src/components/AdminEmpresas.tsx
@@ -35,23 +35,18 @@ export default function AdminEmpresas({
     }
   };
 
-  const startEdit = (idx: number) => {
-    setEditIndex(idx);
-    setEditUsuario(credenciales[idx].usuario);
-    setEditPassword("");
-  };
-
   const handleGuardarEdicion = async () => {
     if (editIndex === null) return;
-    if (!editUsuario.trim() || !editPassword.trim()) return;
+    if (!editNombre.trim() || !editUsuario.trim() || !editPassword.trim()) return;
     const ok = await onEditar(
       credenciales[editIndex].usuario,
-      credenciales[editIndex].empresa || "",
+      editNombre.trim(),
       editUsuario.trim(),
       editPassword.trim()
     );
     if (ok) {
       setEditIndex(null);
+      setEditNombre("");
       setEditUsuario("");
       setEditPassword("");
     }
@@ -116,18 +111,19 @@ export default function AdminEmpresas({
                       <button
                         type="button"
                         className="px-2 py-0.5 text-xs bg-green-500 text-white rounded"
-                        onClick={() => {
-                          onEditar(c.usuario, editNombre, editUsuario, editPassword);
-
-                            setEditIndex(null);
-                        }}
+                        onClick={handleGuardarEdicion}
                       >
                         Guardar
                       </button>
                       <button
                         type="button"
                         className="px-2 py-0.5 text-xs bg-gray-300 rounded"
-                        onClick={() => setEditIndex(null)}
+                        onClick={() => {
+                          setEditIndex(null);
+                          setEditNombre("");
+                          setEditUsuario("");
+                          setEditPassword("");
+                        }}
 
                       >
                         Cancelar
@@ -195,7 +191,12 @@ export default function AdminEmpresas({
         </div>
       ) : (
         <div className="flex flex-wrap gap-2 items-center">
-          <span className="font-semibold">{credenciales[editIndex].empresa}</span>
+          <input
+            className="input flex-1"
+            placeholder="Nombre empresa"
+            value={editNombre}
+            onChange={(e) => setEditNombre(e.target.value)}
+          />
           <input
             className="input flex-1"
             placeholder="Usuario"
@@ -219,7 +220,12 @@ export default function AdminEmpresas({
           <button
             type="button"
             className="px-4 py-1 rounded-lg border"
-            onClick={() => setEditIndex(null)}
+            onClick={() => {
+              setEditIndex(null);
+              setEditNombre("");
+              setEditUsuario("");
+              setEditPassword("");
+            }}
           >
             Cancelar
           </button>

--- a/src/hooks/useCredenciales.ts
+++ b/src/hooks/useCredenciales.ts
@@ -37,7 +37,10 @@ export default function useCredenciales() {
       setCredenciales((prev) => {
         const merged = [...prev];
         extras.forEach((c) => {
-          if (!merged.some((m) => m.usuario === c.usuario)) {
+          const idx = merged.findIndex((m) => m.usuario === c.usuario);
+          if (idx >= 0) {
+            merged[idx] = { ...merged[idx], ...c };
+          } else {
             merged.push(c);
           }
         });
@@ -84,9 +87,11 @@ export default function useCredenciales() {
 
   const eliminarEmpresa = async (usuario: string): Promise<boolean> => {
     const cred = credenciales.find((c) => c.usuario === usuario);
-    if (!cred?.id) return false;
+    if (!cred) return false;
     try {
-      await deleteDoc(doc(db, "credencialesCogent", cred.id));
+      if (cred.id) {
+        await deleteDoc(doc(db, "credencialesCogent", cred.id));
+      }
       setCredenciales((prev) => prev.filter((c) => c.usuario !== usuario));
       return true;
     } catch (err) {
@@ -103,13 +108,15 @@ export default function useCredenciales() {
     password: string
   ): Promise<boolean> => {
     const cred = credenciales.find((c) => c.usuario === originalUsuario);
-    if (!cred?.id) return false;
+    if (!cred) return false;
     try {
-      await updateDoc(doc(db, "credencialesCogent", cred.id), {
-        usuario,
-        password,
-        empresa: nombre,
-      });
+      if (cred.id) {
+        await updateDoc(doc(db, "credencialesCogent", cred.id), {
+          usuario,
+          password,
+          empresa: nombre,
+        });
+      }
       setCredenciales((prev) =>
         prev.map((c) =>
           c.usuario === originalUsuario


### PR DESCRIPTION
## Summary
- ensure Firestore credentials merge preserves document IDs so existing companies can be edited or removed
- allow company deletion/editing to update local state even when no Firestore ID is present
- improve empresa admin UI so edits use the updated name and provide a company name input while editing

## Testing
- npm run build *(fails: missing dependencies/types in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939be6418d08320be2fb15d102639e4)