### PR TITLE
Prevent browser translations

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=Poppins:wght@400&family=Roboto:wght@400&display=swap" rel="stylesheet">
     <meta charset="UTF-8" />
+    <meta http-equiv="Content-Language" content="es" />
     <link rel="icon" type="image/png" href="/logo_forma.png" />
     <link rel="apple-touch-icon" href="/logo_forma.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,7 +3,20 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App'
 
-createRoot(document.getElementById('root')!).render(
+const htmlElement = document.documentElement
+htmlElement.setAttribute('lang', 'es')
+htmlElement.setAttribute('translate', 'no')
+htmlElement.classList.add('notranslate')
+
+const bodyElement = document.body
+bodyElement.setAttribute('translate', 'no')
+bodyElement.classList.add('notranslate')
+
+const rootElement = document.getElementById('root')!
+rootElement.setAttribute('translate', 'no')
+rootElement.classList.add('notranslate')
+
+createRoot(rootElement).render(
   <StrictMode>
     <App />
   </StrictMode>,


### PR DESCRIPTION
## Summary
- declare Spanish content language in the base HTML to reinforce the intended locale
- ensure document and root elements are tagged to block browser translation overlays

## Testing
- npm run build *(fails: existing project TypeScript/dependency errors)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939c295157c8320bd9d1643d2c28516)