### PR TITLE
Permitir acceso a la pestaña Informe para el rol psicóloga

### DIFF
--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -2813,7 +2813,7 @@ export default function DashboardResultados({
 
       <TabsList className="mb-6 py-2 px-4 w-full flex gap-2 overflow-x-auto whitespace-nowrap">
         <TabsTrigger className={tabPill} value="general">General</TabsTrigger>
-        {rol === "superusuario" && (
+        {(rol === "superusuario" || rol === "psicologa") && (
           <TabsTrigger className={tabPill} value="informe">
             Informe
           </TabsTrigger>
@@ -2891,7 +2891,7 @@ export default function DashboardResultados({
           </TabsContent>
         )}
         {/* ---- INFORME ---- */}
-        {rol === "superusuario" && (
+        {(rol === "superusuario" || rol === "psicologa") && (
           <TabsContent value="informe">
             <div className="max-w-4xl mx-auto">
               <section className="bg-white rounded-xl shadow p-6 space-y-6">


### PR DESCRIPTION
### Motivation
- El dashboard de resultados solo mostraba la pestaña y contenido `Informe` al rol `superusuario` y se requiere que el rol `psicologa` también pueda acceder.
- Los usuarios con rol `psicologa` necesitan generar y descargar el PDF del informe desde la interfaz para su trabajo clínico.
- Cambiar las condiciones de visibilidad evita duplicar UI y mantiene el flujo actual de generación de informes.

### Description
- Actualizado el componente `src/components/DashboardResultados.tsx` para ampliar el acceso al informe al rol `psicologa`.
- Reemplazadas las condiciones `rol === "superusuario"` por `(rol === "superusuario" || rol === "psicologa")` en los `TabsTrigger` y `TabsContent` relacionados con `informe`.
- Los cambios afectan únicamente la visibilidad de la pestaña y su contenido; la lógica de generación de PDF y componentes anidados no se modificaron.

### Testing
- No se ejecutaron pruebas automatizadas como parte de este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69495aa9fdfc8320b5e5eea6da677176)