### PR TITLE
Add trash retention and delete confirmations

### DIFF
--- a/src/components/AdminEmpresas.tsx
+++ b/src/components/AdminEmpresas.tsx
@@ -147,6 +147,10 @@ export default function AdminEmpresas({
                         type="button"
                         className="px-2 py-0.5 text-xs bg-red-600 text-white rounded"
                         onClick={async () => {
+                          const confirmado = window.confirm(
+                            `¿Confirmas eliminar la empresa "${c.empresa || c.usuario}"? La información pasará a la papelera por 30 días.`
+                          );
+                          if (!confirmado) return;
                           await onEliminar(c.usuario);
                         }}
                       >

--- a/src/components/DashboardResultados.tsx
+++ b/src/components/DashboardResultados.tsx
@@ -19,7 +19,7 @@ import GeneralResultsTabs from "@/components/dashboard/GeneralResultsTabs";
 import InformeTabs from "@/components/dashboard/InformeTabs";
 import type { IntroduccionData } from "@/report/introduccion";
 import LogoCogent from "/logo_forma.png";
-import { deleteDoc, doc } from "firebase/firestore";
+import { addDoc, collection, deleteDoc, doc } from "firebase/firestore";
 import { db } from "@/firebaseConfig";
 import { buildReportPayload } from "@/utils/buildReportPayload";
 import { ReportPayload } from "@/types/report";
@@ -33,6 +33,7 @@ import useDashboardData from "@/components/dashboard/useDashboardData";
 import DashboardFilters from "@/components/dashboard/DashboardFilters";
 import useDashboardExport from "@/components/dashboard/useDashboardExport";
 import ExportActions from "@/components/dashboard/ExportActions";
+import { toast } from "@/utils/toast";
 
 const nivelesRiesgo = [
   "Riesgo muy bajo",
@@ -2720,16 +2721,43 @@ export default function DashboardResultados({
 
   const eliminarSeleccionados = async () => {
     if (seleccionados.length === 0) return;
+    const confirmacion = window.confirm(
+      `¿Confirmas mover ${seleccionados.length} encuesta(s) a la papelera por 30 días?`
+    );
+    if (!confirmacion) return;
     const eliminados = datos.filter((_, i) => seleccionados.includes(i));
     const restantes = datos.filter((_, i) => !seleccionados.includes(i));
+    const deletedAt = new Date();
+    const expiresAt = new Date(
+      deletedAt.getTime() + 30 * 24 * 60 * 60 * 1000
+    );
+    await Promise.all(
+      eliminados.map((d) =>
+        addDoc(collection(db, "papeleraCogent"), {
+          tipo: "resultado",
+          sourceCollection: "resultadosCogent",
+          sourceId: d.id,
+          deletedAt,
+          expiresAt,
+          data: d,
+        })
+      )
+    );
     await Promise.all(
       eliminados.map((d) => deleteDoc(doc(db, "resultadosCogent", d.id)))
     );
     setDatos(restantes);
     setSeleccionados([]);
+    toast("Encuestas enviadas a la papelera por 30 días.");
   };
 
   const eliminarPorEmpresa = async () => {
+    const confirmacion = window.confirm(
+      `¿Confirmas mover a la papelera las encuestas de "${
+        empresaEliminar === "todas" ? "todas las empresas" : empresaEliminar
+      }" por 30 días?`
+    );
+    if (!confirmacion) return;
     const eliminados =
       empresaEliminar === "todas"
         ? datos
@@ -2738,11 +2766,28 @@ export default function DashboardResultados({
       empresaEliminar === "todas"
         ? []
         : datos.filter((d) => d.ficha?.empresa !== empresaEliminar);
+    const deletedAt = new Date();
+    const expiresAt = new Date(
+      deletedAt.getTime() + 30 * 24 * 60 * 60 * 1000
+    );
+    await Promise.all(
+      eliminados.map((d) =>
+        addDoc(collection(db, "papeleraCogent"), {
+          tipo: "resultado",
+          sourceCollection: "resultadosCogent",
+          sourceId: d.id,
+          deletedAt,
+          expiresAt,
+          data: d,
+        })
+      )
+    );
     await Promise.all(
       eliminados.map((d) => deleteDoc(doc(db, "resultadosCogent", d.id)))
     );
     setDatos(restantes);
     setSeleccionados([]);
+    toast("Encuestas enviadas a la papelera por 30 días.");
   };
 
   // ---- Render tablas individuales (solo para psicóloga) ----

--- a/src/hooks/useCredenciales.ts
+++ b/src/hooks/useCredenciales.ts
@@ -6,6 +6,7 @@ import {
   deleteDoc,
   getDocs,
   doc,
+  collection,
 } from "firebase/firestore";
 import { db } from "../firebaseConfig";
 import { CredencialEmpresa } from "../types";
@@ -89,6 +90,18 @@ export default function useCredenciales() {
     const cred = credenciales.find((c) => c.usuario === usuario);
     if (!cred) return false;
     try {
+      const deletedAt = new Date();
+      const expiresAt = new Date(
+        deletedAt.getTime() + 30 * 24 * 60 * 60 * 1000
+      );
+      await addDoc(collection(db, "papeleraCogent"), {
+        tipo: "empresa",
+        sourceCollection: "credencialesCogent",
+        sourceId: cred.id ?? null,
+        deletedAt,
+        expiresAt,
+        data: cred,
+      });
       if (cred.id) {
         await deleteDoc(doc(db, "credencialesCogent", cred.id));
       }


### PR DESCRIPTION
### Motivation
- Prevent accidental permanent deletions by introducing an intermediate trash state for companies and survey results.  
- Retain deleted items for 30 days to allow recovery or deferred cleanup.  
- Require an explicit user confirmation before performing destructive actions to reduce mistakes.

### Description
- Save a copy of deleted companies and results into a `papeleraCogent` collection with `deletedAt` and `expiresAt` metadata before removing the original documents.  
- Add confirmation dialogs (`window.confirm`) to `AdminEmpresas` and `DashboardResultados` before triggering deletions.  
- Show a toast after moving survey results to the trash and update state to remove items from the UI.  
- Added necessary `addDoc`/`collection` imports and updated `useCredenciales`, `AdminEmpresas`, and `DashboardResultados` to implement the flow.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69495a478f00832086cbe13fd78a127f)