### PR TITLE
Fix duplicate firestore import in useCredenciales

### DIFF
--- a/src/hooks/useCredenciales.ts
+++ b/src/hooks/useCredenciales.ts
@@ -6,7 +6,6 @@ import {
   deleteDoc,
   getDocs,
   doc,
-  collection,
 } from "firebase/firestore";
 import { db } from "../firebaseConfig";
 import { CredencialEmpresa } from "../types";


### PR DESCRIPTION
### Motivation

- The TypeScript build failed with `TS2300: Duplicate identifier 'collection'` in the Firestore hook causing `npm run build` to error.
- Remove the redundant import to restore clean type checking and compilation.

### Description

- Deleted the duplicated `collection` entry from the `firebase/firestore` import in `src/hooks/useCredenciales.ts`.
- No functional changes to the hook logic or runtime behavior were made.

### Testing

- The initial `npm run build` reported the `TS2300` duplicate identifier error before this change.
- No automated tests were run after this fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694960e737f48320a736d4c947a11f9b)